### PR TITLE
Added more robust testing for /api/events

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -97,3 +97,6 @@ typings/
 .tern-port
 
 .DS_Store
+
+#Ignore redis dumps
+dump.rdb


### PR DESCRIPTION
Added a couple of tests for the /api/events route, to ensure that it can properly construct a response if multiple events have been emitted for different instances and different dbIndex values.