### PR TITLE
Built process for recording keyspace histories in RedisMonitors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -100,3 +100,6 @@ typings/
 
 #Ignore redis dumps
 dump.rdb
+
+#Ignore distribution until source code is complete
+dist/

--- a/server/configs/config.json
+++ b/server/configs/config.json
@@ -1,6 +1,7 @@
 [
   {
     "host": "127.0.0.1",
-    "port": 6379
+    "port": 6379,
+    "recordKeyspaceHistoryFrequency": 60000
   }
 ]

--- a/server/controllers/connectionsController.ts
+++ b/server/controllers/connectionsController.ts
@@ -20,7 +20,8 @@ const connectionsController: ConnectionsController = {
           instanceId: idx + 1,
           host: redisMonitor.host,
           port: redisMonitor.port,
-          databases: redisMonitor.databases
+          databases: redisMonitor.databases,
+          recordKeyspaceHistoryFrequency: redisMonitor.recordKeyspaceHistoryFrequency
         }
         connections.instances.push(instance);
       })

--- a/server/redis-monitors/models/data-stores.ts
+++ b/server/redis-monitors/models/data-stores.ts
@@ -8,9 +8,16 @@ Data stores include:
 
 */
 
-import type { KeyspaceEvent as KeyspaceEventElement } from './interfaces';
+import type { 
+  KeyspaceEvent as KeyspaceEventElement, 
+  KeyspaceEventNode,
+  KeyspaceHistory as KeyspaceHistoryElement,
+  KeyspaceHistoryNode,
+  KeyDetails
+} from './interfaces';
 
-export function EventLog(): void {
+export class EventLog {
+
   /*
   Represents a running log of events for a given monitored keyspace.
   Implemented as a doubly-linked list.
@@ -19,8 +26,10 @@ export function EventLog(): void {
   * eventTotal represents the total number of events logged in EventLog.
     * eventTotal still accounts for any KeyspaceEvents that have been deleted
   */
-/*** ------------------ ***/
-export class EventLog {
+  head: null | KeyspaceEventNode;
+  tail: null | KeyspaceEventNode;
+  eventTotal: number;
+
   constructor() {
     this.head = null;
     this.tail = null;
@@ -43,17 +52,17 @@ export class EventLog {
     }
   }
 
-  removeManyViaTimestamp(timestamp: Date): void {
+  removeManyViaTimestamp(timestamp: number): void {
     /*
     Removes all events from the EventLog who have a timestamp earlier than the input timestamp.
     */
   }
 
-  returnLogAsArray(eventTotal = 0) {
-    //this should probably return some sort of error
+  returnLogAsArray(eventTotal = 0): KeyspaceEventElement[] {
+
     if (eventTotal < 0 || eventTotal >= this.eventTotal) return [];
 
-    const logAsArray = [];
+    const logAsArray: KeyspaceEventElement[] = [];
     let count = this.eventTotal - eventTotal;
     let current = this.tail;
 
@@ -72,12 +81,20 @@ export class EventLog {
   }
 }
 
-export class KeyspaceEvent {
+export class KeyspaceEvent implements KeyspaceEventNode {
   /*
   Used to instantiate a new KeyspaceEvent. 
   The event will be timestamped based on the time of instantiation.
   */
-  constructor(key: string, event: string): void {
+
+  key: string;
+  event: string;
+  timestamp: number;
+  next: null | KeyspaceEventNode;
+  previous: null | KeyspaceEventNode;
+
+
+  constructor(key: string, event: string) {
     if (typeof (key) !== 'string' || typeof (event) !== 'string') {
       throw new TypeError('KeyspaceEvent must be constructed with string args');
     }
@@ -111,15 +128,20 @@ An auto-cleanup process would also be recommended.
 */
 
 export class KeyspaceHistoriesLog {
+
+  head: null | KeyspaceHistoryNode;
+  tail: null | KeyspaceHistoryNode;
+  historiesCount: number;
+
   constructor() {
     this.head = null;
     this.tail = null;
     this.historiesCount = 0;
   }
   
-  add(keys: array): void {
-    //ads new events to keyspace histories
-    const newHistory = new KeyspaceHistory(key);
+  add(keyDetails: KeyDetails[]): void {
+    //adds new events to keyspace histories
+    const newHistory = new KeyspaceHistory(keyDetails);
     this.historiesCount += 1;
     if (!this.head) {
       this.head = newHistory;
@@ -131,18 +153,17 @@ export class KeyspaceHistoriesLog {
     }
   }
 
-  returnLogAsArray(historiesCount = 0) {
+  returnLogAsArray(historiesCount = 0): KeyspaceHistoryElement[] {
     //need error handling
     if (historiesCount < 0 || historiesCount >= this.historiesCount) return [];
 
-    const logAsArray = [];
+    const logAsArray: KeyspaceHistoryElement[] = [];
     let count = this.historiesCount - historiesCount;
     let current = this.tail;
 
     while (count > 0) {
       const history = {
         keys: current.keys,
-        history: current.history,
         timestamp: current.timestamp
       };
 
@@ -154,11 +175,16 @@ export class KeyspaceHistoriesLog {
   }
 };
 
-export class KeyspaceHistory {
-  //instantiates a new keyspace history 
-  constructor(keys: string[]): void {
-    if (typeof (keys) !== 'string' || typeof (history) !== 'string') {
-      throw new TypeError('KeyspaceHistory must be constructed with string arguments')
+export class KeyspaceHistory implements KeyspaceHistoryNode {
+  
+  keys: KeyDetails[];
+  timestamp: number;
+  next: null | KeyspaceHistoryNode;
+  previous: null | KeyspaceHistoryNode;
+
+  constructor(keys: KeyDetails[]) {
+    if (!Array.isArray(keys)) {
+      throw new TypeError('KeyspaceHistory must be constructed with an array of KeyDetails')
     }
     this.keys = keys;
     this.timestamp = Date.now();
@@ -166,3 +192,4 @@ export class KeyspaceHistory {
     this.previous = null;
   }
 };
+

--- a/server/redis-monitors/models/interfaces.ts
+++ b/server/redis-monitors/models/interfaces.ts
@@ -7,6 +7,7 @@ import { RedisClient } from 'redis';
 export interface RedisInstance {
   host: string;
   port: number;
+  recordKeyspaceHistoryFrequency: number,
 };
 
 export interface RedisMonitor {
@@ -17,11 +18,12 @@ export interface RedisMonitor {
   port: RedisInstance['port'];
   databases?: number; //Check property - should this be optional on object initialization?
   keyspaces: Keyspace[];
+  recordKeyspaceHistoryFrequency: RedisInstance['recordKeyspaceHistoryFrequency'],
 };
 
 export interface Keyspace {
   eventLog: EventLog;
-  keySnapshots: KeySnapshot[];
+  keyspaceHistories: KeyspaceHistoriesLog;
 };
 
 export interface EventLog {
@@ -34,18 +36,33 @@ export interface EventLog {
 export interface KeyspaceEvent {
   key: string;
   event: string;
-  timestamp: Date;
+  timestamp: number;
 }
 
 export interface KeyspaceEventNode extends KeyspaceEvent {
-  key: string;
-  event: string;
-  timestamp: Date;
-  next: null | KeyspaceEvent;
-  previous: null | KeyspaceEvent;
+  next: null | KeyspaceEventNode;
+  previous: null | KeyspaceEventNode;
 };
 
-export interface KeySnapshot {
-  timestamp: Date;
-  keys: string[];
+export interface KeyspaceHistoriesLog {
+  head: null | KeyspaceHistoryNode;
+  tail: null | KeyspaceHistoryNode;
+  historiesCount: number;
+  add: (keyDetails: KeyDetails[]) => void;
+  returnLogAsArray: (historiesCount: number) => KeyspaceHistory[];
+}
+
+export interface KeyspaceHistory {
+  timestamp: number;
+  keys: KeyDetails[];
 };
+
+export interface KeyspaceHistoryNode extends KeyspaceHistory {
+  next: null | KeyspaceHistoryNode;
+  previous: null | KeyspaceHistoryNode;
+}
+
+export interface KeyDetails {
+  key: string,
+  memoryUsage: number
+}

--- a/server/redis-monitors/utils.ts
+++ b/server/redis-monitors/utils.ts
@@ -1,13 +1,15 @@
 import { RedisClient } from 'redis';
 import { promisify } from 'util';
+import { RedisMonitor, KeyDetails } from './models/interfaces';
 
 export const promisifyClientMethods = (client: RedisClient) => {
 /*
 Promisifies methods of the client.
 */ 
 
-  //redis process
-  client.config = promisify(client.config).bind(client);
+  //redis processes - currently excluded as this method is being used
+  //in callback form - need to refactor existing code before utilizing this
+  // client.config = promisify(client.config).bind(client);
   
   //redis commands: databases
   client.flushdb = promisify(client.flushdb).bind(client);
@@ -24,4 +26,40 @@ Promisifies methods of the client.
   client.mget = promisify(client.mget).bind(client);
 
   return client;
+}
+
+// const getKeyMemoryUsage = async (key: string, client: RedisClient): Promise<number> => {
+// /* 
+// Returns the memory usage, in bytes, for the given key argument.
+// */
+
+// }
+export const recordKeyspaceHistory = async (monitor: RedisMonitor, dbIndex: number): Promise<void> => {
+/*
+Scans the keyspace for the given database index utilizing a RedisMonitor instance.
+Stores the scanned results in the corresponding monitored keyspace's KeyspaceHistoriesLog.
+*/
+  const keyDetails: KeyDetails[] = [];
+  
+  let cursor = '0';
+  let keys: string[] = [];
+  
+  //@ts-ignore
+  [ cursor, keys ] = await monitor.redisClient.scan(cursor)
+
+  do {
+    keys.forEach(key => {
+      keyDetails.push({
+        key: key,
+        memoryUsage: 0
+      });
+    });
+
+    //@ts-ignore - 
+    [ cursor, keys ] = await monitor.redisClient.scan(cursor);
+  }
+  while (cursor !== '0')
+
+  monitor.keyspaces[dbIndex].keyspaceHistories.add(keyDetails);
+
 }


### PR DESCRIPTION
The RedisMonitors are now able to record keyspace histories and store a log of the histories for each monitored database within a given instance.

Specific work done:
* Refactored the data-stores.ts classes for TypeScript support and updated some variable references
* Introduced a config setting that determines how often databases, within a given instance, should have their keyspace histories recorded
* Added a `setInterval` for each monitored db of a RedisMonitor that records a keyspace history based on user-defined frequency (see bullet above)

As a random aside, I also updated the .gitignore to ignore the dist folder for now.