### PR TITLE
Demo app now uses 2 instances

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -100,6 +100,3 @@ typings/
 
 #Ignore redis dumps
 dump.rdb
-
-#Ignore distribution until source code is complete
-dist/

--- a/demo-redis-app/index.js
+++ b/demo-redis-app/index.js
@@ -4,7 +4,11 @@ Imports functionality that mocks Redis commands and executes them at a specified
 
 const mock = require('./utils/mock-commands.js');
 const mockSettings = require('./utils/mock-command-settings.js');
+const redisClients = require('./redis-config/client-config.js');
 
-setInterval(mock.setString, mockSettings.STRING_SET_FREQUENCY);
-setInterval(mock.getString, mockSettings.STRING_GET_FREQUENCY);
-setInterval(mock.delString, mockSettings.STRING_DELETE_FREQUENCY);
+redisClients.forEach(client => {
+  setInterval(mock.setString, mockSettings.STRING_SET_FREQUENCY, client);
+  setInterval(mock.getString, mockSettings.STRING_GET_FREQUENCY, client);
+  setInterval(mock.delString, mockSettings.STRING_DELETE_FREQUENCY, client);
+})
+

--- a/demo-redis-app/redis-config/client-config.js
+++ b/demo-redis-app/redis-config/client-config.js
@@ -13,14 +13,21 @@ we need set standard configurations on the redis database:
 
 const redis = require('redis');
 const { promisify } = require('util');
-const client = redis.createClient();
 
-client.config('SET', 'notify-keyspace-events', 'KEA');
+const clients = [];
 
-client.select = promisify(client.select).bind(client);
+for (let PORT = 6379; PORT < 6381; PORT++) {
 
-client.on('error', (error) => {
-  console.log('Redis client error occured: ', error);
-});
+  const client = redis.createClient({host: '127.0.0.1', port: PORT});
+  client.config('SET', 'notify-keyspace-events', 'KEA');
+  client.select = promisify(client.select).bind(client);
+  client.on('error', (error) => {
+    console.log(`Redis client error occured (port ${PORT}): ${error}
+    Please ensure you have a redis server running on this port.
+    bash: redis-server --port ${PORT}`);
+  });
 
-module.exports = client;
+  clients.push(client);
+}
+
+module.exports = clients;

--- a/demo-redis-app/utils/mock-commands.js
+++ b/demo-redis-app/utils/mock-commands.js
@@ -1,11 +1,10 @@
 /*
 Mocks some common Redis commands. Used by index.js
+All mock command functions should be passed a node-redis client.
 */
 
 const mockData = require('./mock-command-data.js');
 const mockSettings = require('./mock-command-settings');
-const client = require('../redis-config/client-config.js');
-
 
 const selectRandomDatabase = async (client) => {
 //Choose a random database (based on the Redis default of 16 databases for an instance) to perform commands against
@@ -14,7 +13,7 @@ const selectRandomDatabase = async (client) => {
 
 const mockCommands = {};
 
-mockCommands.setString = async () => {
+mockCommands.setString = async (client) => {
 
   await selectRandomDatabase(client);
 
@@ -30,7 +29,7 @@ mockCommands.setString = async () => {
   });
 }
 
-mockCommands.getString = async () => {
+mockCommands.getString = async (client) => {
 
   await selectRandomDatabase(client);
 
@@ -40,7 +39,7 @@ mockCommands.getString = async () => {
   });
 }
 
-mockCommands.delString = async () => {
+mockCommands.delString = async (client) => {
 
   await selectRandomDatabase(client);
 
@@ -50,7 +49,7 @@ mockCommands.delString = async () => {
   });
 }
 
-mockCommands.pushList = () => {
+mockCommands.pushList = (client) => {
   const key = mockData.lists.createKey();
   client.lpush(key, mockData.lists.createValue(), (err, res) => {
     if (!err) console.log(`Key lpush: ${key}`);
@@ -63,21 +62,21 @@ mockCommands.pushList = () => {
   });
 }
 
-mockCommands.smembersList = () => {
+mockCommands.smembersList = (client) => {
   const key = mockData.lists.createKey();
   client.smembers(key, (err, res) => {
     if (!err) console.log(`Retrieved list data for key ${key}: ${res}`);
   });
 }
 
-mockCommands.ltrimList = () => {
+mockCommands.ltrimList = (client) => {
   const key = mockData.lists.createKey();
   client.ltrim(key, 0, -1, (err, res) => {
     if (!err) console.log(`Deleted list key ${key}`)
   });
 }
 
-mockCommands.hmsetHash = () => {
+mockCommands.hmsetHash = (client) => {
   const key = mockData.hashes.createKey();
   client.hmset(key, mockData.hashes.createValue(), (err, res) => {
     if (!err) console.log(`Key hmset ${key}`);
@@ -90,14 +89,14 @@ mockCommands.hmsetHash = () => {
   });
 }
 
-mockCommands.hgetallHash = () => {
+mockCommands.hgetallHash = (client) => {
   const key = mockData.hashes.createKey();
   client.hgetall(key, (err, res) => {
     if (!err) console.log(`Retrieved hash data for key ${key}:  ${res}`)
   });
 }
 
-mockCommands.hdelHash = () => {
+mockCommands.hdelHash = (client) => {
   const key = mockData.hashes.createKey();
   client.hdel(key, user, pass, age, occupation, (err, res) => {
     if (!err) console.log(`Deleted hash key ${key}`)

--- a/dist/server/configs/config.json
+++ b/dist/server/configs/config.json
@@ -1,6 +1,12 @@
 [
   {
     "host": "127.0.0.1",
-    "port": 6379
+    "port": 6379,
+    "recordKeyspaceHistoryFrequency": 60000
+  },
+  {
+    "host": "127.0.0.1",
+    "port": 6380,
+    "recordKeyspaceHistoryFrequency": 60000
   }
 ]

--- a/dist/server/controllers/connectionsController.js
+++ b/dist/server/controllers/connectionsController.js
@@ -15,7 +15,8 @@ var connectionsController = {
                     instanceId: idx + 1,
                     host: redisMonitor.host,
                     port: redisMonitor.port,
-                    databases: redisMonitor.databases
+                    databases: redisMonitor.databases,
+                    recordKeyspaceHistoryFrequency: redisMonitor.recordKeyspaceHistoryFrequency
                 };
                 connections.instances.push(instance);
             });

--- a/dist/server/controllers/utils.js
+++ b/dist/server/controllers/utils.js
@@ -37,21 +37,20 @@ var __generator = (this && this.__generator) || function (thisArg, body) {
 };
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.getKeyspace = void 0;
-var util_1 = require("util");
 var getValue = function (key, type, redisClient) { return __awaiter(void 0, void 0, void 0, function () {
-    var get, value, _a;
+    var value, _a;
     return __generator(this, function (_b) {
         switch (_b.label) {
             case 0:
-                get = util_1.promisify(redisClient.get).bind(redisClient);
                 _a = type;
                 switch (_a) {
                     case 'string': return [3, 1];
                 }
                 return [3, 3];
-            case 1: return [4, get(key)];
+            case 1: return [4, redisClient.get(key)];
             case 2:
                 value = _b.sent();
+                console.log(value);
                 ;
                 return [3, 3];
             case 3:
@@ -61,18 +60,15 @@ var getValue = function (key, type, redisClient) { return __awaiter(void 0, void
     });
 }); };
 var getKeyspace = function (redisClient, dbIdx) { return __awaiter(void 0, void 0, void 0, function () {
-    var res, scan, select, getType, scanResults, cursor, keys, _i, keys_1, key, type, value;
+    var res, scanResults, cursor, keys, _i, keys_1, key, type, value;
     return __generator(this, function (_a) {
         switch (_a.label) {
             case 0:
                 res = [];
-                scan = util_1.promisify(redisClient.scan).bind(redisClient);
-                select = util_1.promisify(redisClient.select).bind(redisClient);
-                getType = util_1.promisify(redisClient.type).bind(redisClient);
-                return [4, select(dbIdx)];
+                return [4, redisClient.select(dbIdx)];
             case 1:
                 _a.sent();
-                return [4, scan('0', 'COUNT', '100')];
+                return [4, redisClient.scan('0', 'COUNT', '100')];
             case 2:
                 scanResults = _a.sent();
                 cursor = scanResults[0];
@@ -84,7 +80,7 @@ var getKeyspace = function (redisClient, dbIdx) { return __awaiter(void 0, void 
             case 4:
                 if (!(_i < keys_1.length)) return [3, 8];
                 key = keys_1[_i];
-                return [4, getType(key)];
+                return [4, redisClient.type(key)];
             case 5:
                 type = _a.sent();
                 return [4, getValue(key, type, redisClient)];
@@ -99,7 +95,7 @@ var getKeyspace = function (redisClient, dbIdx) { return __awaiter(void 0, void 
             case 7:
                 _i++;
                 return [3, 4];
-            case 8: return [4, scan(cursor, 'COUNT', '100')];
+            case 8: return [4, redisClient.scan(cursor, 'COUNT', '100')];
             case 9:
                 scanResults = _a.sent();
                 cursor = scanResults[0];

--- a/dist/server/redis-monitors/models/data-stores.js
+++ b/dist/server/redis-monitors/models/data-stores.js
@@ -1,54 +1,115 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.KeyspaceEvent = exports.EventLog = void 0;
-function EventLog() {
-    this.head = null;
-    this.tail = null;
-    this.eventTotal = 0;
-}
+exports.KeyspaceHistory = exports.KeyspaceHistoriesLog = exports.KeyspaceEvent = exports.EventLog = void 0;
+var EventLog = (function () {
+    function EventLog() {
+        this.head = null;
+        this.tail = null;
+        this.eventTotal = 0;
+    }
+    EventLog.prototype.add = function (key, event) {
+        var newEvent = new KeyspaceEvent(key, event);
+        this.eventTotal += 1;
+        if (!this.head) {
+            this.head = newEvent;
+            this.tail = newEvent;
+        }
+        else {
+            this.tail.next = newEvent;
+            newEvent.previous = this.tail;
+            this.tail = newEvent;
+        }
+    };
+    EventLog.prototype.removeManyViaTimestamp = function (timestamp) {
+    };
+    EventLog.prototype.returnLogAsArray = function (eventTotal) {
+        if (eventTotal === void 0) { eventTotal = 0; }
+        if (eventTotal < 0 || eventTotal >= this.eventTotal)
+            return [];
+        var logAsArray = [];
+        var count = this.eventTotal - eventTotal;
+        var current = this.tail;
+        while (count > 0) {
+            var event_1 = {
+                key: current.key,
+                event: current.event,
+                timestamp: current.timestamp
+            };
+            logAsArray.push(event_1);
+            current = current.previous;
+            count -= 1;
+        }
+        return logAsArray;
+    };
+    return EventLog;
+}());
 exports.EventLog = EventLog;
-function KeyspaceEvent(key, event) {
-    if (typeof (key) !== 'string' || typeof (event) !== 'string') {
-        throw new TypeError('KeyspaceEvent must be constructed with string args');
+var KeyspaceEvent = (function () {
+    function KeyspaceEvent(key, event) {
+        if (typeof (key) !== 'string' || typeof (event) !== 'string') {
+            throw new TypeError('KeyspaceEvent must be constructed with string args');
+        }
+        this.key = key;
+        this.event = event;
+        this.timestamp = Date.now();
+        this.next = null;
+        this.previous = null;
     }
-    this.key = key;
-    this.event = event;
-    this.timestamp = Date.now();
-    this.next = null;
-    this.previous = null;
-}
+    return KeyspaceEvent;
+}());
 exports.KeyspaceEvent = KeyspaceEvent;
-EventLog.prototype.add = function (key, event) {
-    var newEvent = new KeyspaceEvent(key, event);
-    this.eventTotal += 1;
-    if (!this.head) {
-        this.head = newEvent;
-        this.tail = newEvent;
+var KeyspaceHistoriesLog = (function () {
+    function KeyspaceHistoriesLog() {
+        this.head = null;
+        this.tail = null;
+        this.historiesCount = 0;
     }
-    else {
-        this.tail.next = newEvent;
-        newEvent.previous = this.tail;
-        this.tail = newEvent;
+    KeyspaceHistoriesLog.prototype.add = function (keyDetails) {
+        var newHistory = new KeyspaceHistory(keyDetails);
+        this.historiesCount += 1;
+        if (!this.head) {
+            this.head = newHistory;
+            this.tail = newHistory;
+        }
+        else {
+            this.tail.next = newHistory;
+            newHistory.previous = this.tail;
+            this.tail = newHistory;
+        }
+    };
+    KeyspaceHistoriesLog.prototype.returnLogAsArray = function (historiesCount) {
+        if (historiesCount === void 0) { historiesCount = 0; }
+        if (historiesCount < 0 || historiesCount >= this.historiesCount)
+            return [];
+        var logAsArray = [];
+        var count = this.historiesCount - historiesCount;
+        var current = this.tail;
+        while (count > 0) {
+            var history_1 = {
+                keys: current.keys,
+                timestamp: current.timestamp
+            };
+            logAsArray.push(history_1);
+            current = current.previous;
+            count -= 1;
+        }
+        return logAsArray;
+    };
+    return KeyspaceHistoriesLog;
+}());
+exports.KeyspaceHistoriesLog = KeyspaceHistoriesLog;
+;
+var KeyspaceHistory = (function () {
+    function KeyspaceHistory(keys) {
+        if (!Array.isArray(keys)) {
+            throw new TypeError('KeyspaceHistory must be constructed with an array of KeyDetails');
+        }
+        this.keys = keys;
+        this.timestamp = Date.now();
+        this.next = null;
+        this.previous = null;
     }
-};
-EventLog.prototype.returnLogAsArray = function (eventTotal) {
-    if (eventTotal === void 0) { eventTotal = 0; }
-    if (eventTotal < 0 || eventTotal >= this.eventTotal)
-        return [];
-    var logAsArray = [];
-    var count = this.eventTotal - eventTotal;
-    var current = this.tail;
-    while (count > 0) {
-        var event_1 = {
-            key: current.key,
-            event: current.event,
-            timestamp: current.timestamp
-        };
-        logAsArray.push(event_1);
-        current = current.previous;
-        count -= 1;
-    }
-    return logAsArray;
-};
-EventLog.prototype.removeManyViaTimestamp = function (timestamp) {
-};
+    return KeyspaceHistory;
+}());
+exports.KeyspaceHistory = KeyspaceHistory;
+;

--- a/dist/server/redis-monitors/utils.js
+++ b/dist/server/redis-monitors/utils.js
@@ -1,18 +1,86 @@
 "use strict";
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+var __generator = (this && this.__generator) || function (thisArg, body) {
+    var _ = { label: 0, sent: function() { if (t[0] & 1) throw t[1]; return t[1]; }, trys: [], ops: [] }, f, y, t, g;
+    return g = { next: verb(0), "throw": verb(1), "return": verb(2) }, typeof Symbol === "function" && (g[Symbol.iterator] = function() { return this; }), g;
+    function verb(n) { return function (v) { return step([n, v]); }; }
+    function step(op) {
+        if (f) throw new TypeError("Generator is already executing.");
+        while (_) try {
+            if (f = 1, y && (t = op[0] & 2 ? y["return"] : op[0] ? y["throw"] || ((t = y["return"]) && t.call(y), 0) : y.next) && !(t = t.call(y, op[1])).done) return t;
+            if (y = 0, t) op = [op[0] & 2, t.value];
+            switch (op[0]) {
+                case 0: case 1: t = op; break;
+                case 4: _.label++; return { value: op[1], done: false };
+                case 5: _.label++; y = op[1]; op = [0]; continue;
+                case 7: op = _.ops.pop(); _.trys.pop(); continue;
+                default:
+                    if (!(t = _.trys, t = t.length > 0 && t[t.length - 1]) && (op[0] === 6 || op[0] === 2)) { _ = 0; continue; }
+                    if (op[0] === 3 && (!t || (op[1] > t[0] && op[1] < t[3]))) { _.label = op[1]; break; }
+                    if (op[0] === 6 && _.label < t[1]) { _.label = t[1]; t = op; break; }
+                    if (t && _.label < t[2]) { _.label = t[2]; _.ops.push(op); break; }
+                    if (t[2]) _.ops.pop();
+                    _.trys.pop(); continue;
+            }
+            op = body.call(thisArg, _);
+        } catch (e) { op = [6, e]; y = 0; } finally { f = t = 0; }
+        if (op[0] & 5) throw op[1]; return { value: op[0] ? op[1] : void 0, done: true };
+    }
+};
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.promisifyClientMethods = void 0;
+exports.recordKeyspaceHistory = exports.promisifyClientMethods = void 0;
 var util_1 = require("util");
 var promisifyClientMethods = function (client) {
-    var promisified = {};
-    client.config = util_1.promisify(client.config).bind(client);
     client.flushdb = util_1.promisify(client.flushdb).bind(client);
     client.flushall = util_1.promisify(client.flushall).bind(client);
     client.select = util_1.promisify(client.select).bind(client);
-    client.scan = util_1.promisify(client.set).bind(client);
+    client.scan = util_1.promisify(client.scan).bind(client);
     client.type = util_1.promisify(client.type).bind(client);
     client.set = util_1.promisify(client.set).bind(client);
     client.get = util_1.promisify(client.get).bind(client);
-    client.mget = util_1.promisify(client.get).bind(client);
+    client.mget = util_1.promisify(client.mget).bind(client);
     return client;
 };
 exports.promisifyClientMethods = promisifyClientMethods;
+var recordKeyspaceHistory = function (monitor, dbIndex) { return __awaiter(void 0, void 0, void 0, function () {
+    var keyDetails, cursor, keys;
+    var _a, _b;
+    return __generator(this, function (_c) {
+        switch (_c.label) {
+            case 0:
+                keyDetails = [];
+                cursor = '0';
+                keys = [];
+                return [4, monitor.redisClient.scan(cursor)];
+            case 1:
+                _a = _c.sent(), cursor = _a[0], keys = _a[1];
+                _c.label = 2;
+            case 2:
+                keys.forEach(function (key) {
+                    keyDetails.push({
+                        key: key,
+                        memoryUsage: 0
+                    });
+                });
+                return [4, monitor.redisClient.scan(cursor)];
+            case 3:
+                _b = _c.sent(), cursor = _b[0], keys = _b[1];
+                _c.label = 4;
+            case 4:
+                if (cursor !== '0') return [3, 2];
+                _c.label = 5;
+            case 5:
+                monitor.keyspaces[dbIndex].keyspaceHistories.add(keyDetails);
+                return [2];
+        }
+    });
+}); };
+exports.recordKeyspaceHistory = recordKeyspaceHistory;

--- a/server/configs/config.json
+++ b/server/configs/config.json
@@ -3,5 +3,10 @@
     "host": "127.0.0.1",
     "port": 6379,
     "recordKeyspaceHistoryFrequency": 60000
+  },
+  {
+    "host": "127.0.0.1",
+    "port": 6380,
+    "recordKeyspaceHistoryFrequency": 60000
   }
 ]

--- a/server/controllers/utils.ts
+++ b/server/controllers/utils.ts
@@ -10,7 +10,8 @@ const getValue = async (key: string, type: string, redisClient: RedisClient): Pr
 
     case 'string': {
       //@ts-ignore - incorrect type errors for promisified method's return value
-      value = await client.get(key);
+      value = await redisClient.get(key);
+      console.log(value);
     }; break;
 
   };

--- a/server/redis-monitors/redis-monitors.ts
+++ b/server/redis-monitors/redis-monitors.ts
@@ -23,6 +23,8 @@ const redisMonitors: RedisMonitor[] = [];
 
 instances.forEach((instance: RedisInstance, idx: number): void => {
 
+  console.log(idx);
+
   //Promisify methods for the redis client for async/await capability
   const client: redis.RedisClient = promisifyClientMethods(
     redis.createClient({host: instance.host, port: instance.port})


### PR DESCRIPTION
Demo app can now perform operations against redis servers in port 6379 and port 6380.

* When running the demo app, PLEASE ensure that there is also a server running on port 6380. Using bash `redis-server --port 6380`
* Demo app performs equal types/number of operations in both instances

I also made the following changes:
* Copied the config.json (for configuring what instances our app monitors) into the /dist folder - this also resolved a bug that severely degraded performance in our server routes
* Removed dist/ from .gitignore so that now dist files are re-included in commits. This avoids any issues with our team not compiling code when pulling changes.

ONLY files in the demo-redis-app folder need to be reviewed for code changes!