### PR TITLE
Added jest configs for proper setup/teardown for Redis servers

### DIFF
--- a/jestGlobalSetup.js
+++ b/jestGlobalSetup.js
@@ -1,0 +1,31 @@
+/* 
+Start Redis servers prior to tests. 
+
+This is necessary because tests will initiate the RedisMonitors processes,
+which need to instantiate node-redis clients for the instances defined in the tests-config.json
+*/
+
+import 'regenerator-runtime/runtime';
+import RedisServer from 'redis-server';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+
+const testConnections = JSON.parse(readFileSync(resolve(__dirname, './server/configs/tests-config.json')).toString());
+
+module.exports = async () => {
+
+  const servers = [];
+  for (let conn of testConnections) {
+
+    const server = new RedisServer(conn.port);
+    try {
+      await server.open();
+    } catch (e) {
+      console.log(`Error starting server on port ${conn.port}: ${e}`);
+    }
+
+    servers.push(server);
+  }
+
+  global.servers = servers
+}

--- a/jestGlobalTeardown.js
+++ b/jestGlobalTeardown.js
@@ -1,0 +1,5 @@
+module.exports = async () => {
+  for (const server of global.servers) {
+    await server.close();
+  }
+}

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "./client/index.js",
   "scripts": {
     "build": "webpack",
-    "test": "IS_TEST=true jest --verbose --forceExit",
+    "test": "IS_TEST=true jest --verbose",
     "start": "NODE_ENV=production nodemon dist/server/server.js",
     "dev": "NODE_ENV=development webpack serve --open & nodemon dist/server/server.js",
     "cp": "copyfiles -u 1 server/configs/* server/assets/* dist/server/"
@@ -22,7 +22,9 @@
       "ts",
       "tsx",
       "js"
-    ]
+    ],
+    "globalSetup": "./jestGlobalSetup.js",
+    "globalTeardown": "./jestGlobalTeardown.js"
   },
   "repository": {
     "type": "git",

--- a/server/configs/tests-config.json
+++ b/server/configs/tests-config.json
@@ -1,10 +1,12 @@
 [
   {
     "host": "127.0.0.1",
-    "port": 49152
+    "port": 49152,
+    "recordKeyspaceHistoryFrequency": 60000
   },
   {
     "host": "127.0.0.1",
-    "port": 49153
+    "port": 49153,
+    "recordKeyspaceHistoryFrequency": 60000
   }
 ]


### PR DESCRIPTION
This is allowing the test suite to properly run.

Abby and Arthur, this may or may not be helpful in case you guys have issues in your test suites. The global setup/teardown basically allows for test configuration before/after your test files run, although please be aware any variables set in these files are NOT accessible in the test files themselves.  This is useful for setting up and tearing down mock DBs, for example.