### PR TITLE
Keyspace action creators created and updated

### DIFF
--- a/client/action-creators/connections.js
+++ b/client/action-creators/connections.js
@@ -1,56 +1,4 @@
-import * as types from "../actions/actionTypes";
-
-export const updateKeyspaceActionCreator =
-  (instanceId, dbIndex) => (dispatch) => {
-    let url;
-    if (instanceId && dbIndex) {
-      url = `/api/keyspaces/${instanceId}/${dbIndex}`;
-    } else {
-      url = "/api/keyspaces";
-    }
-    fetch(url)
-      .then((res) => res.json())
-      .then((response) => {
-        // console.log('full keyspace data', response.data[0]);
-        let keyspace;
-        if (!dbIndex && !instanceId) {
-          //this will grab all of our databases on the initial
-          keyspace = response.data;
-          dispatch({
-            type: types.UPDATE_KEYSPACE,
-            //is this the proper syntax to add dbIndex??
-            payload: {
-              keyspace: keyspace,
-              // dbIndex: dbIndex,
-              // instanceId: instanceId,
-            },
-          });
-          // } else {
-        }
-        //this we want if our url specifies a specific database
-        else {
-          console.log("response in update keyspace actionc creator", response);
-          keyspace = response.data[instanceId - 1].keyspaces[dbIndex];
-          dispatch({
-            type: types.UPDATE_KEYSPACE,
-            //is this the proper syntax to add dbIndex??
-            payload: {
-              keyspace: keyspace,
-              // [
-              //   {
-              //     keyspaces: keyspace,
-              //   },
-              // ],
-              dbIndex: dbIndex,
-              instanceId: instanceId,
-            },
-          });
-        }
-      })
-      .catch((err) => {
-        console.log("error in updateKeyspaceActionCreator: ", err);
-      });
-  };
+import * as types from '../actions/actionTypes';
 
 export const updateEventsActionCreator =
   (instanceId, dbIndex, currIndex) => (dispatch) => {
@@ -58,14 +6,14 @@ export const updateEventsActionCreator =
     if (instanceId && dbIndex && currIndex) {
       url = `/api/events/${instanceId}/${dbIndex}?eventTotal=${currIndex}`;
     } else {
-      url = "/api/events";
+      url = '/api/events';
     }
     fetch(url)
       .then((res) => res.json())
       .then((res) => {
         let events;
         if (!dbIndex) {
-          console.log("events resopnse in updateEventsActionCreator", res);
+          console.log('events resopnse in updateEventsActionCreator', res);
           events = res.data;
         } else {
           events = res.data[0].keyspaces[0];
@@ -82,7 +30,7 @@ export const updateEventsActionCreator =
         // }
       })
       .catch((err) => {
-        console.log("error in updateEventsActionCreator: ", err);
+        console.log('error in updateEventsActionCreator: ', err);
       });
   };
 
@@ -99,13 +47,13 @@ export const updateKeyGraphActionCreator =
         });
       })
       .catch((err) => {
-        console.log("error in keyspaceUpdateActionCreator: ", err);
+        console.log('error in keyspaceUpdateActionCreator: ', err);
       });
   };
 
 //SWITCH DATABASE
 export const switchDatabaseActionCreator = (dbIndex) => (
-  console.log("switched to database", dbIndex),
+  console.log('switched to database', dbIndex),
   {
     type: types.SWITCH_DATABASE,
     payload: dbIndex,
@@ -115,7 +63,7 @@ export const switchDatabaseActionCreator = (dbIndex) => (
 //SWITCH INSTANCE action creator
 
 export const switchInstanceActionCreator = (instanceId) => (
-  console.log("switched to database", instanceId),
+  console.log('switched to database', instanceId),
   {
     type: types.SWITCH_INSTANCE,
     payload: instanceId,
@@ -129,7 +77,7 @@ export const switchInstanceActionCreator = (instanceId) => (
 // port: 6379
 
 export const updateInstanceInfoActionCreator = () => (dispatch) => {
-  fetch("/api/connections")
+  fetch('/api/connections')
     .then((res) => res.json())
     .then((data) => {
       //for stretch features, there may be multiple instances here
@@ -140,7 +88,7 @@ export const updateInstanceInfoActionCreator = () => (dispatch) => {
     })
     .catch((err) => {
       console.log(
-        "error fetching instanceinfo in updateDBInfoActionCreator:",
+        'error fetching instanceinfo in updateDBInfoActionCreator:',
         err
       );
     });

--- a/client/action-creators/keyspaceConnections.js
+++ b/client/action-creators/keyspaceConnections.js
@@ -1,0 +1,44 @@
+import * as types from '../actions/actionTypes';
+
+//called on initial load of app in App.jsx
+// no requirements in for the deployment of this action creator
+//response :
+// {
+//   data: [
+//     {
+//       instanceId: 1,
+//       keyspaces: [
+//         {
+//           keyTotal: 6347,
+//           pageSize: 50,
+//           pageNum: 4,
+//           data: [
+//             {
+//               key: '',
+//               value: any,
+//               type: any,
+//             },
+//           ],
+//         },
+//       ],
+//     },
+//   ];
+// }
+loadKeyspaceActionCreator = () => (dispatch) => {
+  fetch('/api/v2/keyspaces')
+    .then((res) => res.json())
+    .then((response) => {
+      console.log('response in loadKeyspaceActionCreator', response);
+      let fullKeyspace = response.data;
+      dispatch({
+        type: types.LOAD_KEYSPACE,
+        payload: {
+          keyspace: fullKeyspace,
+        },
+      });
+    });
+};
+
+refreshKeyspaceActionCreator = () => (dispatch) => {};
+
+changeKeyspacePageActionCreator = () => (dispatch) => {};

--- a/client/action-creators/keyspaceConnections.js
+++ b/client/action-creators/keyspaceConnections.js
@@ -7,7 +7,7 @@ import * as types from '../actions/actionTypes';
 //   data: [ (array of instances)
 //     {
 //       instanceId: 1,
-//       keyspaces: [ (array of keyspaces)
+//       keyspaces: [ (array of databases)
 //         {
 //           keyTotal: 6347,
 //           pageSize: 50,
@@ -67,6 +67,8 @@ refreshKeyspaceActionCreator =
           type: types.REFRESH_KEYSPACE,
           payload: {
             keyspace: refreshKeyspace,
+            currInstance: instanceId,
+            currDatabase: dbIndex,
           },
         });
       });
@@ -109,6 +111,8 @@ changeKeyspacePageActionCreator =
           type: types.CHANGE_KEYSPACE_PAGE,
           payload: {
             keyspace: nextPageKeyspace,
+            currInstance: instanceId,
+            currDatabase: dbIndex,
           },
         });
       });

--- a/client/action-creators/keyspaceConnections.js
+++ b/client/action-creators/keyspaceConnections.js
@@ -4,10 +4,10 @@ import * as types from '../actions/actionTypes';
 // no requirements in for the deployment of this action creator
 //response :
 // {
-//   data: [
+//   data: [ (array of instances)
 //     {
 //       instanceId: 1,
-//       keyspaces: [
+//       keyspaces: [ (array of keyspaces)
 //         {
 //           keyTotal: 6347,
 //           pageSize: 50,
@@ -71,5 +71,45 @@ refreshKeyspaceActionCreator =
         });
       });
   };
+//change the page and handle the filters for keyspace
+//requirements: instanceId, dbIndex, page Size, page num, keyname filter, keytype filter, refreshScan = 0 - need to know whether there is a
+//OPTIONS PARAMETER BEING USED HERE CALLED QUERYOPTIONS
+//response:
+// {
+//     keyTotal: 6347,
+//     pageSize: 50,
+//     pageNum: 4,
+//     data: [
+//         {
+//             key: '',
+//             value: '',
+//             type: any,
+//         }
+//     ]
+// }
+changeKeyspacePageActionCreator =
+  (instanceId, dbIndex, queryOptions) => (dispatch) => {
+    let URI = `api/v2/keyspaces/${instanceId}/${dbIndex}/?`;
+    //this may have an issue in here - be aware of queryOptions
+    if (queryOptions.pageSize) URI += `pageSize=${queryOptions.pageSize}`;
+    if (queryOptions.pageNum) URI += `&pageNum=${queryOptions.pageNum}`;
+    if (queryOptions.keyNameFilter)
+      URI += `&keyNameFilter=${queryOptions.keyNameFilter}`;
+    if (queryOptions.keyTypeFilter)
+      URI += `&keyTypeFilter=${queryOptions.keyTypeFilter}`;
+    if (queryOptions.refreshScan)
+      URI += `&refreshScan=${queryOptions.refreshScan}`;
 
-changeKeyspacePageActionCreator = () => (dispatch) => {};
+    fetch(URI)
+      .then((res) => res.json)
+      .then((response) => {
+        console.log('response in changeKeyspaceActionCreator', response);
+        let nextPageKeyspace = response;
+        dispatch({
+          type: types.CHANGE_KEYSPACE_PAGE,
+          payload: {
+            keyspace: nextPageKeyspace,
+          },
+        });
+      });
+  };

--- a/client/action-creators/keyspaceConnections.js
+++ b/client/action-creators/keyspaceConnections.js
@@ -24,7 +24,7 @@ import * as types from '../actions/actionTypes';
 //     },
 //   ];
 // }
-loadKeyspaceActionCreator = () => (dispatch) => {
+export const loadKeyspaceActionCreator = () => (dispatch) => {
   fetch('/api/v2/keyspaces')
     .then((res) => res.json())
     .then((response) => {
@@ -54,7 +54,7 @@ loadKeyspaceActionCreator = () => (dispatch) => {
 //         }
 //     ]
 // }
-refreshKeyspaceActionCreator =
+export const refreshKeyspaceActionCreator =
   (instanceId, dbIndex, pageSize, pageNum, refreshScan) => (dispatch) => {
     fetch(
       `api/v2/keyspaces/${instanceId}/${dbIndex}/?pageSize=${pageSize}&pageNum=${pageNum}&refreshScan=${refreshScan}`
@@ -89,7 +89,7 @@ refreshKeyspaceActionCreator =
 //         }
 //     ]
 // }
-changeKeyspacePageActionCreator =
+export const changeKeyspacePageActionCreator =
   (instanceId, dbIndex, queryOptions) => (dispatch) => {
     let URI = `api/v2/keyspaces/${instanceId}/${dbIndex}/?`;
     //this may have an issue in here - be aware of queryOptions

--- a/client/action-creators/keyspaceConnections.js
+++ b/client/action-creators/keyspaceConnections.js
@@ -39,6 +39,37 @@ loadKeyspaceActionCreator = () => (dispatch) => {
     });
 };
 
-refreshKeyspaceActionCreator = () => (dispatch) => {};
+//for refreshing the keyspace of a certain database at a certain instance - need to know if there are filters or not for dispatch
+// arguments: database, instance, page size, page num = 1, refreshScan = 1,
+//response:
+// {
+//     keyTotal: 6347,
+//     pageSize: 50,
+//     pageNum: 4,
+//     data: [
+//         {
+//             key: '',
+//             value: '',
+//             type: any,
+//         }
+//     ]
+// }
+refreshKeyspaceActionCreator =
+  (instanceId, dbIndex, pageSize, pageNum, refreshScan) => (dispatch) => {
+    fetch(
+      `api/v2/keyspaces/${instanceId}/${dbIndex}/?pageSize=${pageSize}&pageNum=${pageNum}&refreshScan=${refreshScan}`
+    )
+      .then((res) => res.json())
+      .then((response) => {
+        console.log('response in refreshKeyspaceActionCreator', response);
+        let refreshKeyspace = response;
+        dispatch({
+          type: types.REFRESH_KEYSPACE,
+          payload: {
+            keyspace: refreshKeyspace,
+          },
+        });
+      });
+  };
 
 changeKeyspacePageActionCreator = () => (dispatch) => {};

--- a/client/reducers/keyspaceReducer.js
+++ b/client/reducers/keyspaceReducer.js
@@ -1,5 +1,5 @@
 //leave these separate for future developers in case they want to add functionality
-import * as types from "../actions/actionTypes.js";
+import * as types from '../actions/actionTypes.js';
 
 const initialState = {
   currInstance: 1,
@@ -8,13 +8,18 @@ const initialState = {
     {
       instanceId: 1,
       keyspaces: [
-        [
-          {
-            key: "abigail",
-            type: "set",
-            value: "hello Arthur",
-          },
-        ],
+        {
+          keyTotal: 1,
+          pageSize: 50,
+          pageNum: 4,
+          data: [
+            {
+              key: 'loading',
+              type: 'loading',
+              value: 'loading',
+            },
+          ],
+        },
       ],
     },
   ],
@@ -24,23 +29,52 @@ const keyspaceReducer = (state = initialState, action) => {
   let keyspace;
 
   switch (action.type) {
-    case types.UPDATE_KEYSPACE: {
-      //we want to update the kesypace at index database
-      console.log("action payload in keyspace reducer", action.payload);
-      if (!action.payload.dbIndex && !action.payload.instanceId) {
-        const allKeyspaces = action.payload.keyspace;
-        keyspace = state.keyspace.slice();
-        keyspace = allKeyspaces;
-      } else {
-        const dbIndex = action.payload.dbIndex;
-        const newKeyspace = action.payload.keyspace;
-        console.log("action payload on refresh", action.payload.keyspace);
-        const instanceId = action.payload.instanceId;
-        keyspace = state.keyspace.slice();
+    case types.LOAD_KEYSPACE: {
+      console.log(
+        'action payload in LOAD_KEYSPACE keyspace reducer',
+        action.payload
+      );
 
-        keyspace[instanceId - 1].keyspaces[dbIndex].push(...newKeyspace);
-      }
+      const fullKeyspace = action.payload.keyspace;
+      keyspace = state.keyspace.slice();
+      keyspace = fullKeyspace;
 
+      return {
+        ...state,
+        keyspace,
+      };
+    }
+    case types.REFRESH_KEYSPACE: {
+      //this is for a particular database in a particular instance
+      console.log(
+        'action payload in REFRESH_KEYSPACE keyspace reducer',
+        action.payload
+      );
+      const specificKeyspace = action.payload.keyspace;
+      const currInstance = action.payload.currInstance;
+      const currDatabase = action.payload.currDatabase;
+
+      keyspace = state.keyspace.slice();
+      keyspace[currInstance - 1].keyspaces[currDatabase] = specificKeyspace;
+      //do I need to update the database and isntance?
+      return {
+        ...state,
+        keyspace,
+      };
+    }
+    case types.CHANGE_KEYSPACE_PAGE: {
+      console.log(
+        'action payload in CHANGE_KEYSPACE_PAGE keyspace reducer',
+        action.payload
+      );
+
+      const specificKeyspace = action.payload.keyspace;
+      const currInstance = action.payload.currInstance;
+      const currDatabase = action.payload.currDatabase;
+
+      keyspace = state.keyspace.slice();
+      keyspace[currInstance - 1].keyspaces[currDatabase] = specificKeyspace;
+      //do I need to update the database and instance?
       return {
         ...state,
         keyspace,


### PR DESCRIPTION
Deleted old keyspaceActionCreator in connections.js
created the file keyspaceConnections.js for the new action creators
created three new action types and deleted UPDATE_KEYSPACE action type
updated keyspaceReducer.js to handle the three different action types with a switch case.

there are a couple things that could possibly cause issues:
1.queryOptions object paremeter in keyspaceConnections.js
2. do we possibly need to update the currDatabase and currInstance state in the reducers that have those in their payload - i don't believe so
3. returning the full keyspace after altering a single database of a single instance. 

I believe all of these have been done correctly, but they are things to look at if there are issues with the code.