### PR TITLE
Keyspace Histories route w/ tests

### DIFF
--- a/__tests__/server/v2routes.ts
+++ b/__tests__/server/v2routes.ts
@@ -6,21 +6,22 @@ import { promisify } from 'util'; //promisify some node-redis client functionali
 
 import app from '../../server/server';
 import redisMonitors from '../../server/redis-monitors/redis-monitors'
+import { recordKeyspaceHistory } from '../../server/redis-monitors/utils';
 
 const testConnections = JSON.parse(readFileSync(resolve(__dirname, '../../server/configs/tests-config.json')).toString());
 
 enum ENDPOINT_NAMES { KEYSPACES, KEYSPACE_HISTORIES, EVENTS, EVENT_TOTALS };
 
-
 describe('Route Integration Tests', () => {
 
-  type redisModel = {
+  type RedisModel = {
     client: redis.RedisClient;
     host: string;
     port: number;
     instanceId: number;
+    recordKeyspaceHistoryFrequency: number;
   }
-  let redisModels: redisModel[] = [];
+  let redisModels: RedisModel[] = [];
 
   //Start test redis servers and corresponding clients
   beforeAll(async () => {
@@ -35,7 +36,8 @@ describe('Route Integration Tests', () => {
         client: redisClient,
         host: conn.host,
         port: conn.port,
-        instanceId: instanceId
+        instanceId: instanceId,
+        recordKeyspaceHistoryFrequency: conn.recordKeyspaceHistoryFrequency
       };
 
       redisModels.push(redisModel);
@@ -121,6 +123,14 @@ describe('Route Integration Tests', () => {
       for (const model of redisModels) {
         await model.client.flushall();
       }
+
+      //clear out any logs in the monitors
+      for (const monitor of redisMonitors) {
+        for (const keyspace of monitor.keyspaces) {
+          keyspace.eventLog.reset();
+          keyspace.keyspaceHistories.reset()
+        }
+      }
     });
 
     //GET request for all keyspaces across all instances
@@ -180,8 +190,6 @@ describe('Route Integration Tests', () => {
           }));
         });
       });
-
-
     });
 
     //GET request for a specific keyspace
@@ -243,16 +251,154 @@ describe('Route Integration Tests', () => {
     });
   });
 
-  describe('/api/v2/events', () => {
 
-    beforeAll(() => {
-      //clear out any preceding events logged in the monitors
+  describe('/api/v2/keyspaces/histories', () => {
+
+    afterAll(() => {
       for (const monitor of redisMonitors) {
         for (const keyspace of monitor.keyspaces) {
           keyspace.eventLog.reset();
+          keyspace.keyspaceHistories.reset();
         }
       }
     });
+
+    describe('GET /:instanceId/:dbIndex', () => {
+
+      describe('Without query parameters', () => {
+      
+        let response;
+        beforeAll(async () => {
+          /*
+            Utilizes mock timers to periodically use Redis commands and record them at different time intervals
+            After commands are performed, sends request to grab keyspace history.
+          */
+
+          const client = redisModels[0].client;
+          await client.select(0);
+          await client.set('key1', 'val');
+          await client.set('key2', 'val2');
+          await client.lpush('key3', 'el3', 'el2', 'el1');
+          
+
+          //Allow for the first keyspace history to be recorded
+          jest.useFakeTimers();
+          jest.advanceTimersByTime(redisModels[0].recordKeyspaceHistoryFrequency * 1.5);
+
+          await client.set('key4', 'val');
+          await client.set('key5', 'val2');
+          await client.lpush('key6', 'el3', 'el2', 'el1');
+
+          //Allow for the second keyspace history to be recorded
+          jest.advanceTimersByTime(redisModels[0].recordKeyspaceHistoryFrequency);
+
+          //Allow for the third keyspace history to be recorded
+          await client.del('key6');      
+          jest.advanceTimersByTime(redisModels[0].recordKeyspaceHistoryFrequency);
+
+          response = await request(app).get('/api/v2/keyspaces/histories/1/0');
+        });
+
+        afterAll(async () => {
+          for (const monitor of redisMonitors) {
+            for (const keyspace of monitor.keyspaces) {
+              keyspace.keyspaceHistories.reset();
+            }
+          }
+
+          for (const model of redisModels) {
+            await model.client.flushall();
+          }
+        });
+
+        it('should respond with a 200 status code and JSON', async () => {
+          expect(response.status).toEqual(200);
+          expect(response.headers['content-type']).toEqual(
+            expect.stringContaining('json')
+          );
+        });
+
+        //Mocks passage of time in order to test the correct historyCount
+        it('should have return the correct number of histories recorded', () => {
+          expect(response.body.historyCount).toEqual(3);
+          expect(response.body.histories).toHaveLength(3);
+        });
+
+        it('should return the correct data in the histories property', () => {
+
+          const histories = response.body.histories;
+          expect(histories[0].keyCount).toEqual(3);
+          expect(histories[1].keyCount).toEqual(6);
+          expect(histories[2].keyCount).toEqual(5);
+
+          histories.forEach(history => {
+            expect(history.timestamp).toBeLessThanOrEqual(Date.now());
+            expect(history.timestamp).toBeGreaterThanOrEqual(
+              Date.now() - redisModels[0].recordKeyspaceHistoryFrequency * 4
+            );
+            expect(history.memoryUsage).toBeGreaterThan(0);
+          });
+        });
+
+        it('should order the histories from newest to oldest', () => {
+
+          const histories = response.body.histories;
+          expect(histories[0].timestamp).toBeGreaterThanOrEqual(histories[1].timestamp);
+          expect(histories[1].timestamp).toBeGreaterThanOrEqual(histories[2].timestamp);
+        });
+
+      });
+
+      describe('Handling query parameters', () => {
+
+        let response;
+        beforeAll(async () => {
+
+          const client = redisModels[0].client;
+          await client.select(3);
+          await client.set('key1', 'val');
+          await client.set('key2', 'val');
+
+          jest.useFakeTimers();
+          jest.advanceTimersByTime(redisModels[0].recordKeyspaceHistoryFrequency);
+
+          
+          await client.set('beep3', 'val');
+          jest.advanceTimersByTime(redisModels[0].recordKeyspaceHistoryFrequency);
+
+          await client.set('beep4', 'val');
+          jest.advanceTimersByTime(redisModels[0].recordKeyspaceHistoryFrequency);
+
+          response = await request(app).get(`/api/v2/keyspaces/histories/${redisModels[0].instanceId}/3?historiesCount=1&keynameFilter=beep`);
+        });
+
+        afterAll(async () => {
+
+          for (const monitor of redisMonitors) {
+            for (const keyspace of monitor.keyspaces) {
+              keyspace.keyspaceHistories.reset();
+            }
+          }
+          for (const model of redisModels) {
+            await model.client.flushall();
+          }
+        });
+
+        it('should give the right number of histories based on the historiesCount parameter', () => {
+          expect(response.body.historyCount).toEqual(2);
+          expect(response.body.histories).toHaveLength(2);
+        });
+
+        it('the keycounts should reflect the keynameFilter specified', () => {
+          expect(response.body.histories[0].keyCount).toEqual(2);
+          expect(response.body.histories[1].keyCount).toEqual(1);
+        });
+      });
+    });
+
+  })
+
+  describe('/api/v2/events', () => {
 
     describe('GET "/"', () => {
 

--- a/dist/server/redis-monitors/utils.js
+++ b/dist/server/redis-monitors/utils.js
@@ -64,25 +64,28 @@ var recordKeyspaceHistory = function (monitor, dbIndex) { return __awaiter(void 
                 keyDetails = [];
                 cursor = '0';
                 keys = [];
-                return [4, monitor.redisClient.scan(cursor)];
+                return [4, monitor.redisClient.select(dbIndex)];
             case 1:
-                _a = _c.sent(), cursor = _a[0], keys = _a[1];
-                _c.label = 2;
+                _c.sent();
+                return [4, monitor.redisClient.scan(cursor)];
             case 2:
+                _a = _c.sent(), cursor = _a[0], keys = _a[1];
+                _c.label = 3;
+            case 3:
                 keys.forEach(function (key) {
                     keyDetails.push({
                         key: key,
-                        memoryUsage: 0
+                        memoryUsage: 1
                     });
                 });
                 return [4, monitor.redisClient.scan(cursor)];
-            case 3:
-                _b = _c.sent(), cursor = _b[0], keys = _b[1];
-                _c.label = 4;
             case 4:
-                if (cursor !== '0') return [3, 2];
+                _b = _c.sent(), cursor = _b[0], keys = _b[1];
                 _c.label = 5;
             case 5:
+                if (cursor !== '0') return [3, 3];
+                _c.label = 6;
+            case 6:
                 monitor.keyspaces[dbIndex].keyspaceHistories.add(keyDetails);
                 return [2];
         }

--- a/dist/server/routers/keyspacesRouter-v2.js
+++ b/dist/server/routers/keyspacesRouter-v2.js
@@ -16,4 +16,7 @@ router.get('/:instanceId', monitorsController_1.default.findSingleMonitor, keysp
 router.get('/:instanceId/:dbIndex', monitorsController_1.default.findSingleMonitor, keyspacesController_1.default.refreshKeyspace, keyspacesController_1.default.getKeyspacePages, function (req, res) {
     res.status(200).json(res.locals.keyspaces);
 });
+router.get('/histories/:instanceId/:dbIndex', monitorsController_1.default.findSingleMonitor, keyspacesController_1.default.getKeyspaceHistories, function (req, res) {
+    res.status(200).json(res.locals.histories);
+});
 exports.default = router;

--- a/dist/server/routes/keyspacesRouter.js
+++ b/dist/server/routes/keyspacesRouter.js
@@ -15,13 +15,4 @@ router.get('/:instanceId', keyspacesController_1.default.findSingleMonitor, keys
 router.get('/:instanceId/:dbIndex', keyspacesController_1.default.findSingleMonitor, keyspacesController_1.default.getKeyspacesForInstance, function (req, res) {
     res.status(200).json(res.locals.keyspaces);
 });
-router.get('/keyspaces/', keyspacesController_1.default.findAllMonitors, keyspacesController_1.default.refreshKeyspace, keyspacesController_1.default.getKeyspacePages, function (req, res) {
-    res.status(200).json(res.locals.keyspaces);
-});
-router.get('/keyspaces/:instanceId', keyspacesController_1.default.findSingleMonitor, keyspacesController_1.default.refreshKeyspace, keyspacesController_1.default.getKeyspacePages, function (req, res) {
-    res.status(200).json(res.locals.keyspaces);
-});
-router.get('/keyspaces/:instanceId/:dbIndex', keyspacesController_1.default.findSingleMonitor, keyspacesController_1.default.refreshKeyspace, keyspacesController_1.default.getKeyspacePages, function (req, res) {
-    res.status(200).json(res.locals.keyspaces);
-});
 exports.default = router;

--- a/server/controllers/keyspacesController.ts
+++ b/server/controllers/keyspacesController.ts
@@ -3,12 +3,14 @@ import { RequestHandler } from 'express';
 //type definition for response body data
 // import { RedisInstance, Keyspace, KeyData } from './interfaces';
 import type { KeyspacesResponseBody, KeyDetails, Keyspace } from './interfaces';
+import type { KeyspaceHistoriesLog, KeyspaceHistoryNode, KeyDetails as HistoryKeyDetails } from '../redis-monitors/models/interfaces';
 import { getKeyspace } from './utils';
 
 interface KeyspacesController {
   getKeyspacesForInstance: RequestHandler;
   refreshKeyspace: RequestHandler;
   getKeyspacePages: RequestHandler;
+  getKeyspaceHistories: RequestHandler;
 }
 
 const keyspacesController: KeyspacesController = {
@@ -171,8 +173,69 @@ const keyspacesController: KeyspacesController = {
     }
 
     return next();
-  }
+  },
 
+  getKeyspaceHistories: (req, res, next) => {
+  /*
+    Traverses the logged keyspace histories for a single monitor only,
+    and constructs a response body with aggregated keyCount and memoryUsage metrics
+    for each logged history.
+  */ 
+
+    const dbIndex = +req.params.dbIndex;
+    //grab the keyspace histories log for the given monitor
+    const historiesLog: KeyspaceHistoriesLog = res.locals.monitors[0].keyspaces[dbIndex].keyspaceHistories;
+    const requestHistoryCount = +req.query.historiesCount;
+
+    //Check for an invalid historyCount parameter
+    if (requestHistoryCount > historiesLog.historiesCount
+        || (req.params.historyCount && isNaN(requestHistoryCount))) {
+      return next({
+        log: 'Request provided an incorrect historyCount parameter',
+        status: 400,
+        message: {err: 'historyCount is invalid - please ensure it is a number and a valid count received from a previous response'}
+      });
+    }
+
+    const responseData = {
+      historyCount: historiesLog.historiesCount,
+      histories: []
+    }
+
+    //Determine the proper count of histories to grab based on query param
+    let count = requestHistoryCount ? historiesLog.historiesCount - requestHistoryCount : historiesLog.historiesCount;
+    //Traverse the histories log backwards (so newest histories are at the front of the response body)
+
+    let current: KeyspaceHistoryNode = historiesLog.tail;
+    const keynameFilter = req.query.keynameFilter
+
+    while (count > 0) {
+
+      //Filters keynames (if there is a filter parameter)
+      const filteredKeys = keynameFilter ? current.keys.filter((el: HistoryKeyDetails): boolean => {
+        return el.key.includes(keynameFilter.toString());
+      }) : current.keys
+
+      //Get total memory usage for all the filtered keys
+      const totalMemoryUsage = filteredKeys.reduce((acc: number, el: HistoryKeyDetails): number => {
+        return acc + el.memoryUsage;
+      }, 0);
+
+      //Add this history with aggregated detail to the response body
+      responseData.histories.push({
+        timestamp: current.timestamp,
+        keyCount: filteredKeys.length,
+        memoryUsage: totalMemoryUsage
+      });
+      
+      //Move onto next (older) history
+      current = current.previous;
+      count -= 1;
+    }
+
+    res.locals.histories = responseData;
+    return next();
+  }
 };
 
 export default keyspacesController;

--- a/server/redis-monitors/utils.ts
+++ b/server/redis-monitors/utils.ts
@@ -58,14 +58,16 @@ export const recordKeyspaceHistory = async (monitor: RedisMonitor, dbIndex: numb
   let cursor = '0';
   let keys: string[] = [];
 
+  await monitor.redisClient.select(dbIndex);
   //@ts-ignore
   [cursor, keys] = await monitor.redisClient.scan(cursor)
+
 
   do {
     keys.forEach(key => {
       keyDetails.push({
         key: key,
-        memoryUsage: 0
+        memoryUsage: 1
       });
     });
 
@@ -75,5 +77,4 @@ export const recordKeyspaceHistory = async (monitor: RedisMonitor, dbIndex: numb
   while (cursor !== '0')
 
   monitor.keyspaces[dbIndex].keyspaceHistories.add(keyDetails);
-
 }

--- a/server/routers/keyspacesRouter-v2.ts
+++ b/server/routers/keyspacesRouter-v2.ts
@@ -8,7 +8,7 @@ router.get('/',
   monitorsController.findAllMonitors,
   keyspacesController.refreshKeyspace,
   keyspacesController.getKeyspacePages,
-  (req: express.Request, res: express.Response) => {
+  (req: express.Request, res: express.Response): void => {
     res.status(200).json(res.locals.keyspaces)
   }
 );
@@ -17,7 +17,7 @@ router.get('/:instanceId',
   monitorsController.findSingleMonitor,
   keyspacesController.refreshKeyspace,
   keyspacesController.getKeyspacePages,
-  (req: express.Request, res: express.Response) => {
+  (req: express.Request, res: express.Response): void => {
     res.status(200).json(res.locals.keyspaces)
   }
 );
@@ -27,8 +27,15 @@ router.get('/:instanceId/:dbIndex',
   monitorsController.findSingleMonitor,
   keyspacesController.refreshKeyspace,
   keyspacesController.getKeyspacePages,
-  (req: express.Request, res: express.Response) => {
+  (req: express.Request, res: express.Response): void => {
     res.status(200).json(res.locals.keyspaces);
+});
+
+router.get('/histories/:instanceId/:dbIndex',
+  monitorsController.findSingleMonitor,
+  keyspacesController.getKeyspaceHistories,
+  (req: express.Request, res: express.Response): void => {
+    res.status(200).json(res.locals.histories);
 });
 
 export default router;


### PR DESCRIPTION
Created this route. Seems to work.

Added test coverage for the route. 
* I ended up scrapping the use of mock timers for passing time necessary for the RedisMonitors process to periodically record keyspace histories, but it appears the scoping of the mock timer is incompatible with how the RedisMonitors process is imported at the top level of the test file. That's my guess why it did not work.
* Instead, I manually called the `recordKeyspaceHistory` functionality for a given keyspace in order to record some keyspace histories for the tests.

The route itself:
* Just one route in the KeyspacesController
* Traverses the keyspace histories log linked list, filtering out keys as necessary based on the keynameFilter parameter, and aggregates each history's data.

I also caught and fixed a bug, in which the `recordKeyspaceHistory` function used for periodically capturing histories failed to select the proper database to scan on.