### PR TITLE
Added support for connecting via URL

### DIFF
--- a/__tests__/server/v2routes.ts
+++ b/__tests__/server/v2routes.ts
@@ -91,9 +91,6 @@ describe('Route Integration Tests', () => {
     it('should provide the correct connection details', () => {
 
       response.body.instances.forEach((instanceDetail, idx) => {
-
-        //Each instance detail object in the response body
-        //Should contain the corresponding instance object from the test connections JSON
         expect(instanceDetail).toEqual(expect.objectContaining(
           testConnections[idx]
         ));

--- a/client/components/navbars/InstanceComponent.jsx
+++ b/client/components/navbars/InstanceComponent.jsx
@@ -4,9 +4,9 @@ const InstanceComponent = (props) => {
   return (
     <div className='instance-container'>
       <p className='instance-display-text' onClick={() => {
-        props.switchInstance(props.instanceDetails.instanceId);
+        props.switchInstance(props.instanceId);
       }}>
-        Instance: {props.instanceDetails.host}@{props.instanceDetails.port}
+        Instance: {props.instanceDisplayName}
       </p>
       {props.databases}
     </div>

--- a/client/components/navbars/InstanceNav.jsx
+++ b/client/components/navbars/InstanceNav.jsx
@@ -45,9 +45,20 @@ class InstanceNav extends Component {
           />
       }
 
+      let instanceDisplayName;
+      if (instance.host && instance.port) {
+        instanceDisplayName = `${instance.host}@${instance.port}`
+      } else if (instance.url) {
+        instanceDisplayName = instance.url;
+      } else {
+        instanceDisplayName = 'N/A';
+      }
+
       instances.push(
         <InstanceComponent
           instanceDetails={instance}
+          instanceId={instance.instanceId}
+          instanceDisplayName={instanceDisplayName}
           databases={databases}
           switchInstance={this.props.switchInstance}
           key={`instance-${idx}`}

--- a/client/reducers/instanceInfoReducer.js
+++ b/client/reducers/instanceInfoReducer.js
@@ -4,8 +4,9 @@ import * as types from "../actions/actionTypes.js";
 const initialState = {
   instanceInfo: [
     {
-      host: "",
-      port: "",
+      host: '',
+      port: '',
+      url: '',
       databases: 0,
       instanceId: 1,
       recordKeyspaceHistoryFrequency: 0,

--- a/dist/server/configs/config.json
+++ b/dist/server/configs/config.json
@@ -5,8 +5,7 @@
     "recordKeyspaceHistoryFrequency": 60000
   },
   {
-    "host": "127.0.0.1",
-    "port": 6380,
+    "url": "redis://127.0.0.1:6380",
     "recordKeyspaceHistoryFrequency": 60000
   }
 ]

--- a/dist/server/configs/tests-config.json
+++ b/dist/server/configs/tests-config.json
@@ -1,10 +1,12 @@
 [
   {
     "host": "127.0.0.1",
-    "port": 49152
+    "port": 49152,
+    "recordKeyspaceHistoryFrequency": 60000
   },
   {
-    "host": "127.0.0.1",
-    "port": 49153
+    "url": "redis://127.0.0.1:49153",
+    "port": 49153,
+    "recordKeyspaceHistoryFrequency": 60000
   }
 ]

--- a/dist/server/controllers/connectionsController.js
+++ b/dist/server/controllers/connectionsController.js
@@ -15,6 +15,7 @@ var connectionsController = {
                     instanceId: idx + 1,
                     host: redisMonitor.host,
                     port: redisMonitor.port,
+                    url: redisMonitor.url,
                     databases: redisMonitor.databases,
                     recordKeyspaceHistoryFrequency: redisMonitor.recordKeyspaceHistoryFrequency
                 };

--- a/dist/server/controllers/utils.js
+++ b/dist/server/controllers/utils.js
@@ -47,7 +47,7 @@ var getValue = function (key, type, redisClient) { return __awaiter(void 0, void
                     case 'string': return [3, 1];
                     case 'list': return [3, 3];
                     case 'set': return [3, 5];
-                    case 'sortedSet': return [3, 7];
+                    case 'zset': return [3, 7];
                     case 'hash': return [3, 9];
                 }
                 return [3, 11];

--- a/dist/server/redis-monitors/redis-monitors.js
+++ b/dist/server/redis-monitors/redis-monitors.js
@@ -60,6 +60,7 @@ var path = __importStar(require("path"));
 var redis = __importStar(require("redis"));
 var data_stores_1 = require("./models/data-stores");
 var utils_1 = require("./utils");
+var utils_2 = require("../controllers/utils");
 var instances = process.env.IS_TEST ?
     JSON.parse(fs.readFileSync(path.resolve(__dirname, '../configs/tests-config.json')).toString())
     : JSON.parse(fs.readFileSync(path.resolve(__dirname, '../configs/config.json')).toString());
@@ -94,24 +95,42 @@ var initMonitor = function (monitor) { return __awaiter(void 0, void 0, void 0, 
                 return [3, 7];
             case 7:
                 _loop_1 = function (dbIndex) {
-                    var keyspace = {
-                        eventLog: new data_stores_1.EventLog(),
-                        keyspaceHistories: new data_stores_1.KeyspaceHistoriesLog(),
-                        keyspaceSnapshot: [],
-                        eventLogSnapshot: []
-                    };
-                    monitor.keyspaces.push(keyspace);
-                    monitor.keyspaceSubscriber.on('pmessage', function (channel, message, event) {
-                        if (+message.match(/[0-9*]/)[0] === dbIndex) {
-                            var key = message.replace(/__keyspace@[0-9]*__:/, '');
-                            monitor.keyspaces[dbIndex].eventLog.add(key, event);
+                    var keyspaceSnapshot, keyspace;
+                    return __generator(this, function (_b) {
+                        switch (_b.label) {
+                            case 0: return [4, utils_2.getKeyspace(monitor.redisClient, dbIndex)];
+                            case 1:
+                                keyspaceSnapshot = _b.sent();
+                                keyspace = {
+                                    eventLog: new data_stores_1.EventLog(),
+                                    keyspaceHistories: new data_stores_1.KeyspaceHistoriesLog(),
+                                    keyspaceSnapshot: keyspaceSnapshot,
+                                    eventLogSnapshot: []
+                                };
+                                monitor.keyspaces.push(keyspace);
+                                monitor.keyspaceSubscriber.on('pmessage', function (channel, message, event) {
+                                    if (+message.match(/[0-9*]/)[0] === dbIndex) {
+                                        var key = message.replace(/__keyspace@[0-9]*__:/, '');
+                                        monitor.keyspaces[dbIndex].eventLog.add(key, event);
+                                    }
+                                });
+                                setInterval(utils_1.recordKeyspaceHistory, monitor.recordKeyspaceHistoryFrequency, monitor, dbIndex);
+                                return [2];
                         }
                     });
-                    setInterval(utils_1.recordKeyspaceHistory, monitor.recordKeyspaceHistoryFrequency, monitor, dbIndex);
                 };
-                for (dbIndex = 0; dbIndex < monitor.databases; dbIndex++) {
-                    _loop_1(dbIndex);
-                }
+                dbIndex = 0;
+                _a.label = 8;
+            case 8:
+                if (!(dbIndex < monitor.databases)) return [3, 11];
+                return [5, _loop_1(dbIndex)];
+            case 9:
+                _a.sent();
+                _a.label = 10;
+            case 10:
+                dbIndex++;
+                return [3, 8];
+            case 11:
                 monitor.keyspaceSubscriber.psubscribe('__keyspace@*__:*');
                 return [2];
         }

--- a/dist/server/redis-monitors/redis-monitors.js
+++ b/dist/server/redis-monitors/redis-monitors.js
@@ -64,45 +64,32 @@ var instances = process.env.IS_TEST ?
     JSON.parse(fs.readFileSync(path.resolve(__dirname, '../configs/tests-config.json')).toString())
     : JSON.parse(fs.readFileSync(path.resolve(__dirname, '../configs/config.json')).toString());
 var redisMonitors = [];
-instances.forEach(function (instance, idx) { return __awaiter(void 0, void 0, void 0, function () {
-    var client, subscriber, monitor, e_1, res, e_2, _loop_1, dbIndex;
+var initMonitor = function (monitor) { return __awaiter(void 0, void 0, void 0, function () {
+    var e_1, res, e_2, _loop_1, dbIndex;
     return __generator(this, function (_a) {
         switch (_a.label) {
             case 0:
-                client = utils_1.promisifyClientMethods(redis.createClient({ host: instance.host, port: instance.port }));
-                subscriber = redis.createClient({ host: instance.host, port: instance.port });
-                monitor = {
-                    instanceId: idx + 1,
-                    redisClient: client,
-                    keyspaceSubscriber: subscriber,
-                    host: instance.host,
-                    port: instance.port,
-                    keyspaces: [],
-                    recordKeyspaceHistoryFrequency: instance.recordKeyspaceHistoryFrequency
-                };
-                _a.label = 1;
-            case 1:
-                _a.trys.push([1, 3, , 4]);
+                _a.trys.push([0, 2, , 3]);
                 return [4, monitor.redisClient.config('SET', 'notify-keyspace-events', 'KEA')];
-            case 2:
+            case 1:
                 _a.sent();
-                return [3, 4];
-            case 3:
+                return [3, 3];
+            case 2:
                 e_1 = _a.sent();
                 console.log("Could not configure client to publish keyspace event noficiations");
-                return [3, 4];
-            case 4:
-                _a.trys.push([4, 6, , 7]);
+                return [3, 3];
+            case 3:
+                _a.trys.push([3, 5, , 6]);
                 return [4, monitor.redisClient.config('GET', 'databases')];
-            case 5:
+            case 4:
                 res = _a.sent();
                 monitor.databases = +res[1];
-                return [3, 7];
-            case 6:
+                return [3, 6];
+            case 5:
                 e_2 = _a.sent();
                 console.log("Could not get database count from client");
-                return [3, 7];
-            case 7:
+                return [3, 6];
+            case 6:
                 _loop_1 = function (dbIndex) {
                     var keyspace = {
                         eventLog: new data_stores_1.EventLog(),
@@ -127,5 +114,33 @@ instances.forEach(function (instance, idx) { return __awaiter(void 0, void 0, vo
                 return [2];
         }
     });
-}); });
+}); };
+instances.forEach(function (instance, idx) {
+    var client;
+    var subscriber;
+    if (instance.host && instance.port) {
+        client = redis.createClient({ host: instance.host, port: instance.port });
+        subscriber = redis.createClient({ host: instance.host, port: instance.port });
+    }
+    else if (instance.url) {
+        client = redis.createClient({ url: instance.url });
+        subscriber = redis.createClient({ url: instance.url });
+    }
+    else {
+        console.log("No valid connection host/port or URL provided - check your config. Instance details: " + instance);
+        return;
+    }
+    client = utils_1.promisifyClientMethods(client);
+    var monitor = {
+        instanceId: idx + 1,
+        redisClient: client,
+        keyspaceSubscriber: subscriber,
+        host: instance.host,
+        port: instance.port,
+        url: instance.url,
+        keyspaces: [],
+        recordKeyspaceHistoryFrequency: instance.recordKeyspaceHistoryFrequency
+    };
+    initMonitor(monitor);
+});
 exports.default = redisMonitors;

--- a/dist/server/redis-monitors/redis-monitors.js
+++ b/dist/server/redis-monitors/redis-monitors.js
@@ -69,27 +69,30 @@ var initMonitor = function (monitor) { return __awaiter(void 0, void 0, void 0, 
     return __generator(this, function (_a) {
         switch (_a.label) {
             case 0:
-                _a.trys.push([0, 2, , 3]);
-                return [4, monitor.redisClient.config('SET', 'notify-keyspace-events', 'KEA')];
+                redisMonitors.push(monitor);
+                _a.label = 1;
             case 1:
-                _a.sent();
-                return [3, 3];
+                _a.trys.push([1, 3, , 4]);
+                return [4, monitor.redisClient.config('SET', 'notify-keyspace-events', 'KEA')];
             case 2:
+                _a.sent();
+                return [3, 4];
+            case 3:
                 e_1 = _a.sent();
                 console.log("Could not configure client to publish keyspace event noficiations");
-                return [3, 3];
-            case 3:
-                _a.trys.push([3, 5, , 6]);
-                return [4, monitor.redisClient.config('GET', 'databases')];
+                return [3, 4];
             case 4:
+                _a.trys.push([4, 6, , 7]);
+                return [4, monitor.redisClient.config('GET', 'databases')];
+            case 5:
                 res = _a.sent();
                 monitor.databases = +res[1];
-                return [3, 6];
-            case 5:
+                return [3, 7];
+            case 6:
                 e_2 = _a.sent();
                 console.log("Could not get database count from client");
-                return [3, 6];
-            case 6:
+                return [3, 7];
+            case 7:
                 _loop_1 = function (dbIndex) {
                     var keyspace = {
                         eventLog: new data_stores_1.EventLog(),
@@ -110,7 +113,6 @@ var initMonitor = function (monitor) { return __awaiter(void 0, void 0, void 0, 
                     _loop_1(dbIndex);
                 }
                 monitor.keyspaceSubscriber.psubscribe('__keyspace@*__:*');
-                redisMonitors.push(monitor);
                 return [2];
         }
     });

--- a/server/configs/config.json
+++ b/server/configs/config.json
@@ -5,8 +5,7 @@
     "recordKeyspaceHistoryFrequency": 60000
   },
   {
-    "host": "127.0.0.1",
-    "port": 6380,
+    "url": "redis://127.0.0.1:6380",
     "recordKeyspaceHistoryFrequency": 60000
   }
 ]

--- a/server/configs/tests-config.json
+++ b/server/configs/tests-config.json
@@ -5,7 +5,7 @@
     "recordKeyspaceHistoryFrequency": 60000
   },
   {
-    "host": "127.0.0.1",
+    "url": "redis://127.0.0.1:49153",
     "port": 49153,
     "recordKeyspaceHistoryFrequency": 60000
   }

--- a/server/controllers/connectionsController.ts
+++ b/server/controllers/connectionsController.ts
@@ -20,6 +20,7 @@ const connectionsController: ConnectionsController = {
           instanceId: idx + 1,
           host: redisMonitor.host,
           port: redisMonitor.port,
+          url: redisMonitor.url,
           databases: redisMonitor.databases,
           recordKeyspaceHistoryFrequency: redisMonitor.recordKeyspaceHistoryFrequency
         }

--- a/server/controllers/utils.ts
+++ b/server/controllers/utils.ts
@@ -4,7 +4,6 @@ import { promisify } from 'util';
 
 const getValue = async (key: string, type: string, redisClient: RedisClient): Promise<any> => {
 
-
   let value;
   switch (type) {
 
@@ -24,7 +23,7 @@ const getValue = async (key: string, type: string, redisClient: RedisClient): Pr
       value = await redisClient.smembers(key);
     }; break;
 
-    case 'sortedSet': {
+    case 'zset': {
       //@ts-ignore - incorrect type errors for promisified method's return value
       //note:  will need to include a range with the key to return all values in 
       //the sorted set

--- a/server/redis-monitors/models/interfaces.ts
+++ b/server/redis-monitors/models/interfaces.ts
@@ -5,17 +5,19 @@ Library of interfaces to represent data structures used by the RedisMonitors.
 import { RedisClient } from 'redis';
 
 export interface RedisInstance {
-  host: string;
-  port: number;
+  readonly host?: string;
+  readonly port?: number;
+  readonly url?: string;
   recordKeyspaceHistoryFrequency: number,
 };
 
 export interface RedisMonitor {
-  instanceId: number;
-  redisClient: RedisClient;
-  keyspaceSubscriber: RedisClient;
-  host: RedisInstance['host'];
-  port: RedisInstance['port'];
+  readonly instanceId: number;
+  readonly redisClient: RedisClient;
+  readonly keyspaceSubscriber: RedisClient;
+  host?: RedisInstance['host'];
+  port?: RedisInstance['port'];
+  url?: RedisInstance['url'];
   databases?: number; //Check property - should this be optional on object initialization?
   keyspaces: Keyspace[];
   recordKeyspaceHistoryFrequency: RedisInstance['recordKeyspaceHistoryFrequency'],

--- a/server/redis-monitors/redis-monitors.ts
+++ b/server/redis-monitors/redis-monitors.ts
@@ -14,6 +14,7 @@ import * as redis from 'redis';
 import { RedisInstance, RedisMonitor, Keyspace } from './models/interfaces';
 import { EventLog, KeyspaceHistoriesLog } from './models/data-stores';
 import { promisifyClientMethods, recordKeyspaceHistory } from './utils';
+import { getKeyspace } from '../controllers/utils';
 
 const instances: RedisInstance[] = process.env.IS_TEST ?
   JSON.parse(fs.readFileSync(path.resolve(__dirname, '../configs/tests-config.json')).toString())
@@ -49,10 +50,11 @@ const initMonitor = async (monitor: RedisMonitor): Promise<void> => {
   //This should be futher modularized for readability and maintanability
   for (let dbIndex = 0; dbIndex < monitor.databases; dbIndex++) {
 
+    const keyspaceSnapshot = await getKeyspace(monitor.redisClient, dbIndex);
     const keyspace: Keyspace = {
       eventLog: new EventLog(),
       keyspaceHistories: new KeyspaceHistoriesLog(),
-      keyspaceSnapshot: [],
+      keyspaceSnapshot: keyspaceSnapshot,
       eventLogSnapshot: []
     }
 

--- a/server/redis-monitors/redis-monitors.ts
+++ b/server/redis-monitors/redis-monitors.ts
@@ -21,26 +21,11 @@ const instances: RedisInstance[] = process.env.IS_TEST ?
 
 const redisMonitors: RedisMonitor[] = [];
 
-instances.forEach( async (instance: RedisInstance, idx: number): Promise<void> => {
-
-  //Promisify methods for the redis client for async/await capability
-  const client: redis.RedisClient = promisifyClientMethods(
-    redis.createClient({host: instance.host, port: instance.port})
-  );
-
-  //Subscriber does not require any promisified methods
-  const subscriber: redis.RedisClient = redis.createClient({host: instance.host, port: instance.port});
-
-  const monitor: RedisMonitor = {
-    instanceId: idx + 1,
-    redisClient: client,
-    keyspaceSubscriber: subscriber,
-    host: instance.host,
-    port: instance.port,
-    keyspaces: [],
-    recordKeyspaceHistoryFrequency: instance.recordKeyspaceHistoryFrequency
-  }
-
+const initMonitor = async (monitor: RedisMonitor): Promise<void> => {
+/*
+  For a given initialized RedisMonitor, configures the monitoring behaviors for the monitored instance.
+*/
+  
   //Subscribe to all keyspace events
   try {
     await monitor.redisClient.config('SET', 'notify-keyspace-events', 'KEA');
@@ -92,6 +77,45 @@ instances.forEach( async (instance: RedisInstance, idx: number): Promise<void> =
 
   monitor.keyspaceSubscriber.psubscribe('__keyspace@*__:*')
   redisMonitors.push(monitor);
+
+}
+
+instances.forEach((instance: RedisInstance, idx: number): void => {
+/*
+  For each instance in the config.json, set up a RedisMonitor object
+  initialized with the instance details and a node-redis client for
+  both the redisClient (used for performing general commands) and the keyspaceSubscriber
+*/
+
+  let client: redis.RedisClient;
+  let subscriber: redis.RedisClient;
+  if (instance.host && instance.port) {
+    client = redis.createClient({host: instance.host, port: instance.port});
+    subscriber = redis.createClient({host: instance.host, port: instance.port});
+  } else if (instance.url) {
+    client = redis.createClient({url: instance.url});
+    subscriber = redis.createClient({url: instance.url});
+  } else {
+    console.log(`No valid connection host/port or URL provided - check your config. Instance details: ${instance}`);
+    return
+  }
+
+  //Promisify methods for the redis client for async/await capability
+  //Subscriber does not require any promisified method
+  client = promisifyClientMethods(client);
+
+  const monitor: RedisMonitor = {
+    instanceId: idx + 1,
+    redisClient: client,
+    keyspaceSubscriber: subscriber,
+    host: instance.host,
+    port: instance.port,
+    url: instance.url,
+    keyspaces: [],
+    recordKeyspaceHistoryFrequency: instance.recordKeyspaceHistoryFrequency
+  }
+
+  initMonitor(monitor);
 })
 
 export default redisMonitors;

--- a/server/redis-monitors/redis-monitors.ts
+++ b/server/redis-monitors/redis-monitors.ts
@@ -26,6 +26,7 @@ const initMonitor = async (monitor: RedisMonitor): Promise<void> => {
   For a given initialized RedisMonitor, configures the monitoring behaviors for the monitored instance.
 */
   
+  redisMonitors.push(monitor);
   //Subscribe to all keyspace events
   try {
     await monitor.redisClient.config('SET', 'notify-keyspace-events', 'KEA');
@@ -75,9 +76,7 @@ const initMonitor = async (monitor: RedisMonitor): Promise<void> => {
     ); 
   }
 
-  monitor.keyspaceSubscriber.psubscribe('__keyspace@*__:*')
-  redisMonitors.push(monitor);
-
+  monitor.keyspaceSubscriber.psubscribe('__keyspace@*__:*');
 }
 
 instances.forEach((instance: RedisInstance, idx: number): void => {


### PR DESCRIPTION
We can now connect to Redis instances to monitor via a connection URL.
* Server side checks if a host/port or URL is provided and connects accordingly
* Server provides host/port or URL connection details via the API.
* Client renders either a host/port or URL on the application

I also made minor changes to keyspace scanning:
* Keyspace snapshots are now taken (scanned for) on server start. This means that the front-end can avoid requesting `refreshScan` when loading the app and requesting data for all keyspaces, which increases front-end load times.
* Fixed type name for sorted set to `zset`