### PR TITLE
Added user configuration options

### DIFF
--- a/config.json
+++ b/config.json
@@ -5,6 +5,6 @@
     "recordKeyspaceHistoryFrequency": 300000,
     "maxKeyspaceHistoryCount": 100,
     "eventGraphRefreshFrequency": 10000,
-    "maximumEventLogSize": 500000
+    "maxEventLogSize": 500000
   }
 ]

--- a/config.json
+++ b/config.json
@@ -2,9 +2,10 @@
   {
     "host": "127.0.0.1",
     "port": 6379,
-    "recordKeyspaceHistoryFrequency": 300000,
-    "maxKeyspaceHistoryCount": 100,
+    "recordKeyspaceHistoryFrequency": 10000,
+    "maxKeyspaceHistoryCount": 3,
     "eventGraphRefreshFrequency": 10000,
-    "maxEventLogSize": 500000
+    "maxEventLogSize": 30,
+    "notifyKeyspaceEvents": "KEA"
   }
 ]

--- a/config.json
+++ b/config.json
@@ -3,9 +3,9 @@
     "host": "127.0.0.1",
     "port": 6379,
     "recordKeyspaceHistoryFrequency": 10000,
-    "maxKeyspaceHistoryCount": 3,
+    "maxKeyspaceHistoryCount": 500,
     "eventGraphRefreshFrequency": 10000,
-    "maxEventLogSize": 30,
+    "maxEventLogSize": 10000000,
     "notifyKeyspaceEvents": "KEA"
   }
 ]

--- a/config.json
+++ b/config.json
@@ -2,6 +2,9 @@
   {
     "host": "127.0.0.1",
     "port": 6379,
-    "recordKeyspaceHistoryFrequency": 60000
+    "recordKeyspaceHistoryFrequency": 300000,
+    "maxKeyspaceHistoryCount": 100,
+    "eventGraphRefreshFrequency": 10000,
+    "maximumEventLogSize": 500000
   }
 ]

--- a/demo-redis-app/utils/mockCommands.js
+++ b/demo-redis-app/utils/mockCommands.js
@@ -51,6 +51,7 @@ mockCommands.delString = async (client) => {
     if (!err) console.log(`Key DEL: ${key}`);
     if (err) console.log(`Failed to DELETE ${key}: ${err}`);
   });
+
 }
 
 /* <<<<< Lists >>>>> */

--- a/dist/server/controllers/connectionsController.js
+++ b/dist/server/controllers/connectionsController.js
@@ -20,7 +20,8 @@ var connectionsController = {
                     recordKeyspaceHistoryFrequency: redisMonitor.recordKeyspaceHistoryFrequency,
                     maxKeyspaceHistoryCount: redisMonitor.maxKeyspaceHistoryCount,
                     eventGraphRefreshFrequency: redisMonitor.eventGraphRefreshFrequency,
-                    maxEventLogSize: redisMonitor.maxEventLogSize
+                    maxEventLogSize: redisMonitor.maxEventLogSize,
+                    notifyKeyspaceEvents: redisMonitor.notifyKeyspaceEvents
                 };
                 connections.instances.push(instance);
             });

--- a/dist/server/controllers/connectionsController.js
+++ b/dist/server/controllers/connectionsController.js
@@ -17,7 +17,10 @@ var connectionsController = {
                     port: redisMonitor.port,
                     url: redisMonitor.url,
                     databases: redisMonitor.databases,
-                    recordKeyspaceHistoryFrequency: redisMonitor.recordKeyspaceHistoryFrequency
+                    recordKeyspaceHistoryFrequency: redisMonitor.recordKeyspaceHistoryFrequency,
+                    maxKeyspaceHistoryCount: redisMonitor.maxKeyspaceHistoryCount,
+                    eventGraphRefreshFrequency: redisMonitor.eventGraphRefreshFrequency,
+                    maxEventLogSize: redisMonitor.maxEventLogSize
                 };
                 connections.instances.push(instance);
             });

--- a/dist/server/controllers/eventsController.js
+++ b/dist/server/controllers/eventsController.js
@@ -156,7 +156,7 @@ var eventsController = {
         var eventTotalParam = +req.query.eventTotal;
         if (eventTotalParam > eventLog.eventTotal ||
             (eventTotalParam && isNaN(eventTotalParam))) {
-            console.log("req.query", req.query);
+            console.log("req.query", req.query, eventLog.eventTotal);
             return next({
                 log: "Client provided an invalid eventTotal query parameter value",
                 status: 400,
@@ -166,6 +166,8 @@ var eventsController = {
             });
         }
         var eventCountToTraverse = eventLog.eventTotal - eventTotalParam;
+        if (eventCountToTraverse > eventLog.length)
+            eventCountToTraverse = eventLog.length;
         var eventCount = 0;
         var current = eventLog.tail;
         var keynameFilter = req.query.keynameFilter

--- a/dist/server/controllers/keyspacesController.js
+++ b/dist/server/controllers/keyspacesController.js
@@ -228,6 +228,7 @@ var keyspacesController = {
             histories: []
         };
         var count = requestHistoryCount ? historiesLog.historiesCount - requestHistoryCount : historiesLog.historiesCount;
+        count = count > historiesLog.length ? historiesLog.length : count;
         var current = historiesLog.tail;
         var keynameFilter = req.query.keynameFilter;
         while (count > 0) {

--- a/dist/server/redis-monitors/models/data-stores.js
+++ b/dist/server/redis-monitors/models/data-stores.js
@@ -2,12 +2,21 @@
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.KeyspaceHistory = exports.KeyspaceHistoriesLog = exports.KeyspaceEvent = exports.EventLog = void 0;
 var EventLog = (function () {
-    function EventLog() {
+    function EventLog(maxLength) {
+        if (!Number.isInteger(maxLength) || maxLength <= 0)
+            throw new TypeError('maxLength must be positive integer!');
         this.head = null;
         this.tail = null;
         this.eventTotal = 0;
+        this.length = 0;
+        this.maxLength = maxLength;
     }
     EventLog.prototype.add = function (key, event) {
+        if (this.length >= this.maxLength) {
+            this.head = this.head.next;
+            this.head.previous = null;
+            this.length -= 1;
+        }
         var newEvent = new KeyspaceEvent(key, event);
         this.eventTotal += 1;
         if (!this.head) {
@@ -24,8 +33,7 @@ var EventLog = (function () {
         this.head = null;
         this.tail = null;
         this.eventTotal = 0;
-    };
-    EventLog.prototype.removeManyViaTimestamp = function (timestamp) {
+        this.length = 0;
     };
     EventLog.prototype.returnLogAsArray = function (eventTotal) {
         if (eventTotal === void 0) { eventTotal = 0; }
@@ -64,12 +72,21 @@ var KeyspaceEvent = (function () {
 }());
 exports.KeyspaceEvent = KeyspaceEvent;
 var KeyspaceHistoriesLog = (function () {
-    function KeyspaceHistoriesLog() {
+    function KeyspaceHistoriesLog(maxLength) {
+        if (!Number.isInteger(maxLength) || maxLength <= 0)
+            throw new TypeError('maxLength must be positive integer!');
         this.head = null;
         this.tail = null;
         this.historiesCount = 0;
+        this.maxLength = maxLength;
+        this.length = 0;
     }
     KeyspaceHistoriesLog.prototype.add = function (keyDetails) {
+        if (this.length >= this.maxLength) {
+            this.head = this.head.next;
+            this.head.previous = null;
+            this.length -= 1;
+        }
         var newHistory = new KeyspaceHistory(keyDetails);
         this.historiesCount += 1;
         if (!this.head) {
@@ -86,6 +103,7 @@ var KeyspaceHistoriesLog = (function () {
         this.head = null;
         this.tail = null;
         this.historiesCount = 0;
+        this.length = 0;
     };
     KeyspaceHistoriesLog.prototype.returnLogAsArray = function (historiesCount) {
         if (historiesCount === void 0) { historiesCount = 0; }

--- a/dist/server/redis-monitors/models/data-stores.js
+++ b/dist/server/redis-monitors/models/data-stores.js
@@ -19,6 +19,7 @@ var EventLog = (function () {
         }
         var newEvent = new KeyspaceEvent(key, event);
         this.eventTotal += 1;
+        this.length += 1;
         if (!this.head) {
             this.head = newEvent;
             this.tail = newEvent;
@@ -41,6 +42,8 @@ var EventLog = (function () {
             return [];
         var logAsArray = [];
         var count = this.eventTotal - eventTotal;
+        if (this.length < count)
+            count = this.length;
         var current = this.tail;
         while (count > 0) {
             var event_1 = {
@@ -89,6 +92,7 @@ var KeyspaceHistoriesLog = (function () {
         }
         var newHistory = new KeyspaceHistory(keyDetails);
         this.historiesCount += 1;
+        this.length += 1;
         if (!this.head) {
             this.head = newHistory;
             this.tail = newHistory;
@@ -111,6 +115,8 @@ var KeyspaceHistoriesLog = (function () {
             return [];
         var logAsArray = [];
         var count = this.historiesCount - historiesCount;
+        if (this.length < count)
+            count = this.length;
         var current = this.tail;
         while (count > 0) {
             var history_1 = {

--- a/dist/server/redis-monitors/redis-monitors.js
+++ b/dist/server/redis-monitors/redis-monitors.js
@@ -100,7 +100,7 @@ var initMonitor = function (monitor) { return __awaiter(void 0, void 0, void 0, 
                     return __generator(this, function (_b) {
                         switch (_b.label) {
                             case 0:
-                                eventLog = new data_stores_1.EventLog();
+                                eventLog = new data_stores_1.EventLog(monitor.maxEventLogSize);
                                 monitor.keyspaceSubscriber.on('pmessage', function (channel, message, event) {
                                     if (+message.match(/[0-9]+/)[0] === dbIndex) {
                                         var key = message.replace(/__keyspace@[0-9]*__:/, '');
@@ -112,7 +112,7 @@ var initMonitor = function (monitor) { return __awaiter(void 0, void 0, void 0, 
                                 keyspaceSnapshot = _b.sent();
                                 keyspace = {
                                     eventLog: eventLog,
-                                    keyspaceHistories: new data_stores_1.KeyspaceHistoriesLog(),
+                                    keyspaceHistories: new data_stores_1.KeyspaceHistoriesLog(monitor.maxKeyspaceHistoryCount),
                                     keyspaceSnapshot: keyspaceSnapshot,
                                     eventLogSnapshot: []
                                 };
@@ -161,7 +161,10 @@ instances.forEach(function (instance, idx) {
         port: instance.port,
         url: instance.url,
         keyspaces: [],
-        recordKeyspaceHistoryFrequency: instance.recordKeyspaceHistoryFrequency
+        recordKeyspaceHistoryFrequency: instance.recordKeyspaceHistoryFrequency,
+        maxKeyspaceHistoryCount: instance.maxKeyspaceHistoryCount,
+        eventGraphRefreshFrequency: instance.eventGraphRefreshFrequency,
+        maxEventLogSize: instance.maxEventLogSize
     };
     initMonitor(monitor);
 });

--- a/dist/server/redis-monitors/redis-monitors.js
+++ b/dist/server/redis-monitors/redis-monitors.js
@@ -74,14 +74,16 @@ var initMonitor = function (monitor) { return __awaiter(void 0, void 0, void 0, 
                 _a.label = 1;
             case 1:
                 _a.trys.push([1, 3, , 4]);
-                return [4, monitor.redisClient.config('SET', 'notify-keyspace-events', 'KEA')];
+                return [4, monitor.redisClient.config('SET', 'notify-keyspace-events', monitor.notifyKeyspaceEvents)];
             case 2:
                 _a.sent();
                 return [3, 4];
             case 3:
                 e_1 = _a.sent();
-                console.log("Could not configure client to publish keyspace event noficiations");
-                return [3, 4];
+                console.log('Could not configure client to publish keyspace event notifications.\n' +
+                    'This instance will not be monitored. Please check the notifyKeyspaceEvents setting ' +
+                    'in the config.json');
+                return [2];
             case 4:
                 _a.trys.push([4, 6, , 7]);
                 return [4, monitor.redisClient.config('GET', 'databases')];
@@ -164,7 +166,8 @@ instances.forEach(function (instance, idx) {
         recordKeyspaceHistoryFrequency: instance.recordKeyspaceHistoryFrequency,
         maxKeyspaceHistoryCount: instance.maxKeyspaceHistoryCount,
         eventGraphRefreshFrequency: instance.eventGraphRefreshFrequency,
-        maxEventLogSize: instance.maxEventLogSize
+        maxEventLogSize: instance.maxEventLogSize,
+        notifyKeyspaceEvents: instance.notifyKeyspaceEvents
     };
     initMonitor(monitor);
 });

--- a/dist/server/server/tests-config/tests-config.json
+++ b/dist/server/server/tests-config/tests-config.json
@@ -2,11 +2,17 @@
   {
     "host": "127.0.0.1",
     "port": 49152,
-    "recordKeyspaceHistoryFrequency": 60000
+    "recordKeyspaceHistoryFrequency": 300000,
+    "maxKeyspaceHistoryCount": 100,
+    "eventGraphRefreshFrequency": 10000,
+    "maxEventLogSize": 500000
   },
   {
     "url": "redis://127.0.0.1:49153",
     "port": 49153,
-    "recordKeyspaceHistoryFrequency": 60000
+    "recordKeyspaceHistoryFrequency": 300000,
+    "maxKeyspaceHistoryCount": 100,
+    "eventGraphRefreshFrequency": 10000,
+    "maxEventLogSize": 500000
   }
 ]

--- a/src/server/controllers/connectionsController.ts
+++ b/src/server/controllers/connectionsController.ts
@@ -25,7 +25,7 @@ const connectionsController: ConnectionsController = {
           recordKeyspaceHistoryFrequency: redisMonitor.recordKeyspaceHistoryFrequency,
           maxKeyspaceHistoryCount: redisMonitor.maxKeyspaceHistoryCount,
           eventGraphRefreshFrequency: redisMonitor.eventGraphRefreshFrequency,
-          maximumEventLogSize: redisMonitor.maximumEventLogSize
+          maxEventLogSize: redisMonitor.maxEventLogSize
         }
         connections.instances.push(instance);
       })

--- a/src/server/controllers/connectionsController.ts
+++ b/src/server/controllers/connectionsController.ts
@@ -22,7 +22,10 @@ const connectionsController: ConnectionsController = {
           port: redisMonitor.port,
           url: redisMonitor.url,
           databases: redisMonitor.databases,
-          recordKeyspaceHistoryFrequency: redisMonitor.recordKeyspaceHistoryFrequency
+          recordKeyspaceHistoryFrequency: redisMonitor.recordKeyspaceHistoryFrequency,
+          maxKeyspaceHistoryCount: redisMonitor.maxKeyspaceHistoryCount,
+          eventGraphRefreshFrequency: redisMonitor.eventGraphRefreshFrequency,
+          maximumEventLogSize: redisMonitor.maximumEventLogSize
         }
         connections.instances.push(instance);
       })

--- a/src/server/controllers/connectionsController.ts
+++ b/src/server/controllers/connectionsController.ts
@@ -25,7 +25,8 @@ const connectionsController: ConnectionsController = {
           recordKeyspaceHistoryFrequency: redisMonitor.recordKeyspaceHistoryFrequency,
           maxKeyspaceHistoryCount: redisMonitor.maxKeyspaceHistoryCount,
           eventGraphRefreshFrequency: redisMonitor.eventGraphRefreshFrequency,
-          maxEventLogSize: redisMonitor.maxEventLogSize
+          maxEventLogSize: redisMonitor.maxEventLogSize,
+          notifyKeyspaceEvents: redisMonitor.notifyKeyspaceEvents
         }
         connections.instances.push(instance);
       })

--- a/src/server/controllers/eventsController.ts
+++ b/src/server/controllers/eventsController.ts
@@ -255,7 +255,7 @@ const eventsController: EventsController = {
       eventTotalParam > eventLog.eventTotal ||
       (eventTotalParam && isNaN(eventTotalParam))
     ) {
-      console.log("req.query", req.query);
+      console.log("req.query", req.query, eventLog.eventTotal);
       return next({
         log: "Client provided an invalid eventTotal query parameter value",
         status: 400,
@@ -268,8 +268,11 @@ const eventsController: EventsController = {
     //Traverse backwards through the event log until we've reached the event the client is aware of
     //Only aggregate event counts for events that meet filter criteria
     let eventCountToTraverse = eventLog.eventTotal - eventTotalParam;
+    if (eventCountToTraverse > eventLog.length) eventCountToTraverse = eventLog.length;
+
     let eventCount = 0;
     let current: KeyspaceEventNode = eventLog.tail;
+
     const keynameFilter: string = req.query.keynameFilter
       ? req.query.keynameFilter.toString()
       : "";

--- a/src/server/controllers/keyspacesController.ts
+++ b/src/server/controllers/keyspacesController.ts
@@ -181,7 +181,6 @@ const keyspacesController: KeyspacesController = {
     and constructs a response body with aggregated keyCount and memoryUsage metrics
     for each logged history.
   */ 
-
     const dbIndex = +req.params.dbIndex;
     //grab the keyspace histories log for the given monitor
     const historiesLog: KeyspaceHistoriesLog = res.locals.monitors[0].keyspaces[dbIndex].keyspaceHistories;
@@ -202,15 +201,15 @@ const keyspacesController: KeyspacesController = {
       histories: []
     }
 
-    //Determine the proper count of histories to grab based on query param
+    //Determine the proper count of histories to grab based on query param; cannot exceed log length
     let count = requestHistoryCount ? historiesLog.historiesCount - requestHistoryCount : historiesLog.historiesCount;
-    //Traverse the histories log backwards (so newest histories are at the front of the response body)
+    count = count > historiesLog.length ? historiesLog.length : count
 
+    //Traverse the histories log backwards (so newest histories are at the front of the response body)
     let current: KeyspaceHistoryNode = historiesLog.tail;
     const keynameFilter = req.query.keynameFilter
 
     while (count > 0) {
-
       //Filters keynames (if there is a filter parameter)
       const filteredKeys = keynameFilter ? current.keys.filter((el: HistoryKeyDetails): boolean => {
         return el.key.includes(keynameFilter.toString());
@@ -227,7 +226,7 @@ const keyspacesController: KeyspacesController = {
         keyCount: filteredKeys.length,
         memoryUsage: totalMemoryUsage
       });
-      
+
       //Move onto next (older) history
       current = current.previous;
       count -= 1;

--- a/src/server/redis-monitors/models/data-stores.ts
+++ b/src/server/redis-monitors/models/data-stores.ts
@@ -61,6 +61,7 @@ export class EventLog {
 
     const newEvent = new KeyspaceEvent(key, event);
     this.eventTotal += 1;
+    this.length += 1;
     if (!this.head) {
       this.head = newEvent;
       this.tail = newEvent;
@@ -84,9 +85,17 @@ export class EventLog {
     if (eventTotal < 0 || eventTotal >= this.eventTotal) return [];
 
     const logAsArray: KeyspaceEventElement[] = [];
+    
+  
     let count = this.eventTotal - eventTotal;
-    let current = this.tail;
+    /* 
+      In cases where some events have been dropped from the event log,
+      Ensure that we do not try to return more events 
+      than are currently stored in the log
+    */
+    if (this.length < count) count = this.length;
 
+    let current = this.tail;
     while (count > 0) {
       const event = {
         key: current.key,
@@ -179,6 +188,7 @@ export class KeyspaceHistoriesLog {
 
     const newHistory = new KeyspaceHistory(keyDetails);
     this.historiesCount += 1;
+    this.length += 1;
     if (!this.head) {
       this.head = newHistory;
       this.tail = newHistory
@@ -202,7 +212,14 @@ export class KeyspaceHistoriesLog {
     if (historiesCount < 0 || historiesCount >= this.historiesCount) return [];
 
     const logAsArray: KeyspaceHistoryElement[] = [];
+
     let count = this.historiesCount - historiesCount;
+    /* 
+      In cases where some events have been dropped from the event log,
+      Ensure that we do not try to return more events 
+      than are currently stored in the log
+    */
+    if (this.length < count) count = this.length;
     let current = this.tail;
 
     while (count > 0) {

--- a/src/server/redis-monitors/models/interfaces.ts
+++ b/src/server/redis-monitors/models/interfaces.ts
@@ -8,10 +8,11 @@ export interface RedisInstance {
   readonly host?: string;
   readonly port?: number;
   readonly url?: string;
-  readonly recordKeyspaceHistoryFrequency: number,
-  readonly maxKeyspaceHistoryCount: number,
-  readonly eventGraphRefreshFrequency: number,
-  readonly maxEventLogSize: number,
+  readonly recordKeyspaceHistoryFrequency: number;
+  readonly maxKeyspaceHistoryCount: number;
+  readonly eventGraphRefreshFrequency: number;
+  readonly maxEventLogSize: number;
+  readonly notifyKeyspaceEvents: string;
 };
 
 export interface RedisMonitor {
@@ -27,6 +28,7 @@ export interface RedisMonitor {
   readonly maxKeyspaceHistoryCount: RedisInstance['maxKeyspaceHistoryCount'];
   readonly eventGraphRefreshFrequency: RedisInstance['eventGraphRefreshFrequency'];
   readonly maxEventLogSize: RedisInstance['maxEventLogSize'];
+  readonly notifyKeyspaceEvents: RedisInstance['notifyKeyspaceEvents'];
 };
 
 export interface Keyspace {
@@ -44,6 +46,8 @@ export interface EventLog {
   head: null | KeyspaceEventNode;
   tail: null | KeyspaceEventNode;
   eventTotal: number;
+  maxLength: number;
+  length: number;
   add: (key: string, event: string) => void;
   reset: () => void;
   returnLogAsArray: (eventTotal: number) => KeyspaceEvent[];
@@ -63,6 +67,8 @@ export interface KeyspaceHistoriesLog {
   head: null | KeyspaceHistoryNode;
   tail: null | KeyspaceHistoryNode;
   historiesCount: number;
+  maxLength: number;
+  length: number;
   add: (keyDetails: KeyDetails[]) => void;
   reset: () => void;
   returnLogAsArray: (historiesCount: number) => KeyspaceHistory[];

--- a/src/server/redis-monitors/models/interfaces.ts
+++ b/src/server/redis-monitors/models/interfaces.ts
@@ -8,7 +8,10 @@ export interface RedisInstance {
   readonly host?: string;
   readonly port?: number;
   readonly url?: string;
-  recordKeyspaceHistoryFrequency: number,
+  readonly recordKeyspaceHistoryFrequency: number,
+  readonly maxKeyspaceHistoryCount: number,
+  readonly eventGraphRefreshFrequency: number,
+  readonly maximumEventLogSize: number,
 };
 
 export interface RedisMonitor {
@@ -20,7 +23,10 @@ export interface RedisMonitor {
   url?: RedisInstance['url'];
   databases?: number; //Check property - should this be optional on object initialization?
   keyspaces: Keyspace[];
-  recordKeyspaceHistoryFrequency: RedisInstance['recordKeyspaceHistoryFrequency'],
+  readonly recordKeyspaceHistoryFrequency: RedisInstance['recordKeyspaceHistoryFrequency'];
+  readonly maxKeyspaceHistoryCount: RedisInstance['maxKeyspaceHistoryCount'];
+  readonly eventGraphRefreshFrequency: RedisInstance['eventGraphRefreshFrequency'];
+  readonly maximumEventLogSize: RedisInstance['maximumEventLogSize'];
 };
 
 export interface Keyspace {

--- a/src/server/redis-monitors/models/interfaces.ts
+++ b/src/server/redis-monitors/models/interfaces.ts
@@ -11,7 +11,7 @@ export interface RedisInstance {
   readonly recordKeyspaceHistoryFrequency: number,
   readonly maxKeyspaceHistoryCount: number,
   readonly eventGraphRefreshFrequency: number,
-  readonly maximumEventLogSize: number,
+  readonly maxEventLogSize: number,
 };
 
 export interface RedisMonitor {
@@ -26,7 +26,7 @@ export interface RedisMonitor {
   readonly recordKeyspaceHistoryFrequency: RedisInstance['recordKeyspaceHistoryFrequency'];
   readonly maxKeyspaceHistoryCount: RedisInstance['maxKeyspaceHistoryCount'];
   readonly eventGraphRefreshFrequency: RedisInstance['eventGraphRefreshFrequency'];
-  readonly maximumEventLogSize: RedisInstance['maximumEventLogSize'];
+  readonly maxEventLogSize: RedisInstance['maxEventLogSize'];
 };
 
 export interface Keyspace {

--- a/src/server/redis-monitors/redis-monitors.ts
+++ b/src/server/redis-monitors/redis-monitors.ts
@@ -112,7 +112,10 @@ instances.forEach((instance: RedisInstance, idx: number): void => {
     port: instance.port,
     url: instance.url,
     keyspaces: [],
-    recordKeyspaceHistoryFrequency: instance.recordKeyspaceHistoryFrequency
+    recordKeyspaceHistoryFrequency: instance.recordKeyspaceHistoryFrequency,
+    maxKeyspaceHistoryCount: instance.maxKeyspaceHistoryCount,
+    eventGraphRefreshFrequency: instance.eventGraphRefreshFrequency,
+    maximumEventLogSize: instance.maximumEventLogSize
   }
 
   initMonitor(monitor);

--- a/src/server/redis-monitors/redis-monitors.ts
+++ b/src/server/redis-monitors/redis-monitors.ts
@@ -30,9 +30,12 @@ const initMonitor = async (monitor: RedisMonitor): Promise<void> => {
   redisMonitors.push(monitor);
   //Subscribe to all keyspace events
   try {
-    await monitor.redisClient.config('SET', 'notify-keyspace-events', 'KEA');
+    await monitor.redisClient.config('SET', 'notify-keyspace-events', monitor.notifyKeyspaceEvents);
   } catch (e) {
-    console.log(`Could not configure client to publish keyspace event noficiations`);
+    console.log('Could not configure client to publish keyspace event notifications.\n' + 
+                'This instance will not be monitored. Please check the notifyKeyspaceEvents setting ' +
+                'in the config.json');
+    return;
   }
 
   let res;
@@ -115,7 +118,8 @@ instances.forEach((instance: RedisInstance, idx: number): void => {
     recordKeyspaceHistoryFrequency: instance.recordKeyspaceHistoryFrequency,
     maxKeyspaceHistoryCount: instance.maxKeyspaceHistoryCount,
     eventGraphRefreshFrequency: instance.eventGraphRefreshFrequency,
-    maxEventLogSize: instance.maxEventLogSize
+    maxEventLogSize: instance.maxEventLogSize,
+    notifyKeyspaceEvents: instance.notifyKeyspaceEvents
   }
 
   initMonitor(monitor);

--- a/src/server/redis-monitors/redis-monitors.ts
+++ b/src/server/redis-monitors/redis-monitors.ts
@@ -51,7 +51,7 @@ const initMonitor = async (monitor: RedisMonitor): Promise<void> => {
   //Additionally auto-saves keyspace histories with frequency in JSON config
   //This should be futher modularized for readability and maintanability
   for (let dbIndex = 0; dbIndex < monitor.databases; dbIndex++) {
-    const eventLog = new EventLog();
+    const eventLog = new EventLog(monitor.maxEventLogSize);
     monitor.keyspaceSubscriber.on('pmessage', (channel: string, message: string, event: string): void => {
       if (+message.match(/[0-9]+/)[0] === dbIndex) {
         const key = message.replace(/__keyspace@[0-9]*__:/, '');
@@ -62,7 +62,7 @@ const initMonitor = async (monitor: RedisMonitor): Promise<void> => {
     const keyspaceSnapshot = await getKeyspace(monitor.redisClient, dbIndex);
     const keyspace: Keyspace = {
       eventLog: eventLog,
-      keyspaceHistories: new KeyspaceHistoriesLog(),
+      keyspaceHistories: new KeyspaceHistoriesLog(monitor.maxKeyspaceHistoryCount),
       keyspaceSnapshot: keyspaceSnapshot,
       eventLogSnapshot: []
     }
@@ -115,7 +115,7 @@ instances.forEach((instance: RedisInstance, idx: number): void => {
     recordKeyspaceHistoryFrequency: instance.recordKeyspaceHistoryFrequency,
     maxKeyspaceHistoryCount: instance.maxKeyspaceHistoryCount,
     eventGraphRefreshFrequency: instance.eventGraphRefreshFrequency,
-    maximumEventLogSize: instance.maximumEventLogSize
+    maxEventLogSize: instance.maxEventLogSize
   }
 
   initMonitor(monitor);

--- a/src/server/tests-config/tests-config.json
+++ b/src/server/tests-config/tests-config.json
@@ -2,11 +2,17 @@
   {
     "host": "127.0.0.1",
     "port": 49152,
-    "recordKeyspaceHistoryFrequency": 60000
+    "recordKeyspaceHistoryFrequency": 300000,
+    "maxKeyspaceHistoryCount": 100,
+    "eventGraphRefreshFrequency": 10000,
+    "maxEventLogSize": 500000
   },
   {
     "url": "redis://127.0.0.1:49153",
     "port": 49153,
-    "recordKeyspaceHistoryFrequency": 60000
+    "recordKeyspaceHistoryFrequency": 300000,
+    "maxKeyspaceHistoryCount": 100,
+    "eventGraphRefreshFrequency": 10000,
+    "maxEventLogSize": 500000
   }
 ]

--- a/src/server/tests-config/tests-config.json
+++ b/src/server/tests-config/tests-config.json
@@ -5,7 +5,8 @@
     "recordKeyspaceHistoryFrequency": 300000,
     "maxKeyspaceHistoryCount": 100,
     "eventGraphRefreshFrequency": 10000,
-    "maxEventLogSize": 500000
+    "maxEventLogSize": 500000,
+    "notifyKeyspaceEvents": "KEA"
   },
   {
     "url": "redis://127.0.0.1:49153",
@@ -13,6 +14,7 @@
     "recordKeyspaceHistoryFrequency": 300000,
     "maxKeyspaceHistoryCount": 100,
     "eventGraphRefreshFrequency": 10000,
-    "maxEventLogSize": 500000
+    "maxEventLogSize": 500000,
+    "notifyKeyspaceEvents": "KEA"
   }
 ]


### PR DESCRIPTION
User can now specify a variety of additional configuration options:

* maxKeyspaceHistoryCount: sets the maximum number of keyspace histories that can be recorded for each keyspace of an instance.
* eventGraphRefreshFrequency: the time interval (in milliseconds) at which the event graphs should make additional API requests for new event data
* maxEventLogSize: the maximum number of events to be stored for each keyspace of an instance.
* notifyKeyspaceEvents: specify the keyspace events to be notified for. Based on the CONFIG SET notify-keyspace-events command per the documentation: https://redis.io/topics/notifications

These configuration options need to be used by the GUI (i.e. utilize the frequency settings in the `setInterval` ms parameters in for API calls). The options are provided on app load, when the app makes a request to api/connections.